### PR TITLE
Allow crosscompiling for android

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,10 @@ AC_CHECK_HEADERS(fcntl.h,, [AC_MSG_ERROR([cannot find fcntl.h, bailing out])])
 AC_CHECK_HEADERS(unistd.h,, [AC_MSG_ERROR([cannot find unistd.h, bailing out])])
 AC_CHECK_HEADERS(sys/types.h,, [AC_MSG_ERROR([cannot find sys/types.h, bailing out])])
 AC_CHECK_HEADERS(sys/stat.h,, [AC_MSG_ERROR([cannot find sys/stat.h, bailing out])])
-AC_CHECK_HEADERS(pthread.h, [LIBS="$LIBS -lpthread"])
+AC_CHECK_HEADERS(pthread.h, [
+#ifndef ANDROID
+    LIBS="$LIBS -lpthread" 
+#endif ANDROID])
 AC_CHECK_HEADERS(sys/resource.h,, [AC_MSG_ERROR([cannot find sys/resource.h, bailing out])])
 AC_CHECK_HEADERS(sys/time.h,, [AC_MSG_ERROR([cannot find sys/time.h, bailing out])])
 AC_CHECK_HEADERS(stdint.h,, [AC_MSG_ERROR([cannot find stdint.h, bailing out])])

--- a/include/spatialindex/tools/rand48.h
+++ b/include/spatialindex/tools/rand48.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#ifndef ANDROID
 #ifndef HAVE_SRAND48
 
 #if HAVE_FEATURES_H
@@ -48,4 +48,5 @@ extern double erand48(unsigned short xseed[3]) __THROW;
 
 extern double drand48(void) __THROW;
 
+#endif
 #endif


### PR DESCRIPTION
I ifdeffed tools/rand48.h and lpthread since they are not needed for android
see http://permalink.gmane.org/gmane.linux.ltp/15890
