### PR TITLE
Fix redefinition of integer types for Visual C++

### DIFF
--- a/include/spatialindex/tools/Tools.h
+++ b/include/spatialindex/tools/Tools.h
@@ -28,18 +28,20 @@
 #pragma once
 
 #if defined _WIN32 || defined _WIN64 || defined WIN32 || defined WIN64
-  typedef __int8 int8_t;
-  typedef __int16 int16_t;
-  typedef __int32 int32_t;
-  typedef __int64 int64_t;
-  typedef unsigned __int8 uint8_t;
-  typedef unsigned __int16 uint16_t;
-  typedef unsigned __int32 uint32_t;
-  typedef unsigned __int64 uint64_t;
-
-// Nuke this annoying warning.  See http://www.unknownroad.com/rtfm/VisualStudio/warningC4251.html
-#pragma warning( disable: 4251 )
-
+  #if !defined(_MSC_VER) || (defined(_MSC_VER) && _MSC_VER < 1700)
+    typedef __int8 int8_t;
+    typedef __int16 int16_t;
+    typedef __int32 int32_t;
+    typedef __int64 int64_t;
+    typedef unsigned __int8 uint8_t;
+    typedef unsigned __int16 uint16_t;
+    typedef unsigned __int32 uint32_t;
+    typedef unsigned __int64 uint64_t;
+  #else
+    #include <cstdint>
+  #endif
+  // Nuke this annoying warning.  See http://www.unknownroad.com/rtfm/VisualStudio/warningC4251.html
+  #pragma warning( disable: 4251 )
 #else
   #include <stdint.h>
 #endif

--- a/test/rtree/Exhaustive.cc
+++ b/test/rtree/Exhaustive.cc
@@ -34,19 +34,22 @@
 #define QUERY 2
 
 #if defined _WIN32 || defined _WIN64 || defined WIN32 || defined WIN64
-	typedef __int8 int8_t;
-	typedef __int16 int16_t;
-	typedef __int32 int32_t;
-	typedef __int64 int64_t;
-	typedef unsigned __int8 uint8_t;
-	typedef unsigned __int16 uint16_t;
-	typedef unsigned __int32 uint32_t;
-	typedef unsigned __int64 uint64_t;
-
-	// Nuke this annoying warning.  See http://www.unknownroad.com/rtfm/VisualStudio/warningC4251.html
-	#pragma warning( disable: 4251 )
+  #if !defined(_MSC_VER) || (defined(_MSC_VER) && _MSC_VER < 1700)
+    typedef __int8 int8_t;
+    typedef __int16 int16_t;
+    typedef __int32 int32_t;
+    typedef __int64 int64_t;
+    typedef unsigned __int8 uint8_t;
+    typedef unsigned __int16 uint16_t;
+    typedef unsigned __int32 uint32_t;
+    typedef unsigned __int64 uint64_t;
+  #else
+    #include <cstdint>
+  #endif
+  // Nuke this annoying warning.  See http://www.unknownroad.com/rtfm/VisualStudio/warningC4251.html
+  #pragma warning( disable: 4251 )
 #else
-	#include <stdint.h>
+  #include <stdint.h>
 #endif
 
 class Region


### PR DESCRIPTION
Visual C++ 17.00 now provides `<cstdint>` header with integer types
originally in the C standard library as `<stdint.h>`.

In fact, `stdint.h` (in lines following the patch) should be avoided, but I'm not sure if it isn't required by some older GCC implementations.
