### PR TITLE
Prevent min/max from windef.h interference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ if(WIN32)
       add_definitions(-D_CRT_NONSTDC_NO_WARNING)
       add_definitions(-D_SCL_SECURE_NO_WARNINGS)
       add_definitions(-DSPATIALINDEX_CREATE_DLL=1)
+      add_definitions(-DNOMINMAX)
 
       set(SIDX_COMPILER_MSVC 1)
       if (MSVC11)


### PR DESCRIPTION
This resolves compilation problem for [sidx_api.cc](https://github.com/libspatialindex/libspatialindex/blob/master/src/capi/sidx_api.cc#L315)

http://stackoverflow.com/questions/13416418/define-nominmax-using-stdmin-max
