### PR TITLE
Inaccessible index property IndexIdentifier

### DIFF
--- a/include/spatialindex/capi/Index.h
+++ b/include/spatialindex/capi/Index.h
@@ -32,8 +32,8 @@ class Index
 {
 
 public:
-    Index(const Tools::PropertySet& poProperties);
-    Index(const Tools::PropertySet& poProperties, int (*readNext)(SpatialIndex::id_type *id, double **pMin, double **pMax, uint32_t *nDimension, const uint8_t **pData, uint32_t *nDataLength));
+    Index(Tools::PropertySet& poProperties);
+    Index(Tools::PropertySet& poProperties, int (*readNext)(SpatialIndex::id_type *id, double **pMin, double **pMax, uint32_t *nDimension, const uint8_t **pData, uint32_t *nDataLength));
     ~Index();
 
     const Tools::PropertySet& GetProperties() { return m_properties; }
@@ -67,7 +67,7 @@ private:
     SpatialIndex::StorageManager::IBuffer* m_buffer;
     SpatialIndex::ISpatialIndex* m_rtree;
 
-    Tools::PropertySet m_properties;
+    Tools::PropertySet& m_properties;
 
     void Setup();
     SpatialIndex::IStorageManager* CreateStorage();

--- a/include/spatialindex/tools/Tools.h
+++ b/include/spatialindex/tools/Tools.h
@@ -311,8 +311,8 @@ namespace Tools
 		PropertySet(const byte* data);
 		virtual ~PropertySet();
 
-		Variant getProperty(std::string property);
-		void setProperty(std::string property, Variant& v);
+		Variant getProperty(std::string property) const;
+		void setProperty(std::string property, Variant const& v);
 		void removeProperty(std::string property);
 
 		virtual uint32_t getByteArraySize();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -216,12 +216,12 @@ if (APPLE)
   set_target_properties(
     ${SIDX_LIB_NAME}
     PROPERTIES
-    INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib" BUILD_WITH_INSTALL_RPATH ON)
+    INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib" BUILD_WITH_INSTALL_RPATH OFF)
 
   set_target_properties(
     ${SIDX_C_LIB_NAME}
     PROPERTIES
-    INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib" BUILD_WITH_INSTALL_RPATH ON)
+    INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib" BUILD_WITH_INSTALL_RPATH OFF)
 endif()
 
 ###############################################################################

--- a/src/capi/Index.cc
+++ b/src/capi/Index.cc
@@ -73,11 +73,9 @@ SpatialIndex::ISpatialIndex* Index::CreateIndex()
 }
 
 
-Index::Index(const Tools::PropertySet& poProperties)
+Index::Index(Tools::PropertySet& poProperties): m_properties(poProperties)
 {
 	Setup();
-
-	m_properties = poProperties;
 
 	Initialize();
 }
@@ -90,19 +88,18 @@ Index::~Index()
 	delete m_storage;
 }
 
-Index::Index(	const Tools::PropertySet& poProperties,
+Index::Index(	Tools::PropertySet& poProperties,
 				int (*readNext)(SpatialIndex::id_type *id,
 								double **pMin,
 								double **pMax,
 								uint32_t *nDimension,
 								const uint8_t **pData,
 								uint32_t *nDataLength))
+: m_properties(poProperties)
 {
 	using namespace SpatialIndex;
 
 	Setup();
-
-	m_properties = poProperties;
 
 	m_storage = CreateStorage();
 	m_buffer = CreateIndexBuffer(*m_storage);

--- a/src/storagemanager/DiskStorageManager.cc
+++ b/src/storagemanager/DiskStorageManager.cc
@@ -144,8 +144,8 @@ DiskStorageManager::DiskStorageManager(Tools::PropertySet& ps) : m_pageSize(0), 
 
 	if (var.m_varType != Tools::VT_EMPTY)
 	{
-		if (var.m_varType != Tools::VT_PCHAR ||
-            var.m_varType != Tools::VT_PWCHAR)
+		if (!(var.m_varType == Tools::VT_PCHAR ||
+            var.m_varType == Tools::VT_PWCHAR))
 			throw Tools::IllegalArgumentException("SpatialIndex::DiskStorageManager: Property FileName must be Tools::VT_PCHAR or Tools::VT_PWCHAR");
 
 		std::string idx("idx");

--- a/src/tools/Tools.cc
+++ b/src/tools/Tools.cc
@@ -348,15 +348,15 @@ void Tools::PropertySet::storeToByteArray(byte** data, uint32_t& length)
 	assert(ptr == (*data) + length);
 }
 
-Tools::Variant Tools::PropertySet::getProperty(std::string property)
+Tools::Variant Tools::PropertySet::getProperty(std::string property) const
 {
-   	std::map<std::string, Variant>::iterator it = m_propertySet.find(property);
+   	std::map<std::string, Variant>::const_iterator it = m_propertySet.find(property);
 
    	if (it != m_propertySet.end()) return (*it).second;
    	else return Variant();
 }
 
-void Tools::PropertySet::setProperty(std::string property, Variant& v)
+void Tools::PropertySet::setProperty(std::string property, Variant const& v)
 {
 	std::pair<std::map<std::string, Variant>::iterator, bool> ret;
 	std::map<std::string, Variant>::iterator it;


### PR DESCRIPTION
I was implementing a custom storage manager the other day and had a few issues getting the IndexIdentifier through the C API. I could always be missing a call to find it somewhere, but my reading of things makes it appear to be hidden.

Near as I can tell, the IndexIdentifier is set on the PropertySet instance here:

https://github.com/libspatialindex/libspatialindex/blob/53fe4df16d3499f85e2aa6e7805f3cc97714ce66/src/rtree/RTree.cc#L394

That PropertySet is the member on the un-namespaced Index class from the C API here:

https://github.com/libspatialindex/libspatialindex/blob/53fe4df16d3499f85e2aa6e7805f3cc97714ce66/include/spatialindex/capi/Index.h#L70

But the Index_GetProperties call ends up returning the PropertySet from the underlying instance that the unnamespaced Index wraps:

https://github.com/libspatialindex/libspatialindex/blob/53fe4df16d3499f85e2aa6e7805f3cc97714ce66/src/capi/sidx_api.cc#L1170

The two solutions i saw were to either patch each of the indexes to set the IndexIdentifier in the PropertySet that they return, or to return a PropertySet that is some sort of merge between the two Index instances. I'm not super familiar with the library internals so I didn't really know which approach would be preferred. For the time being I just peek into the Index class directly so its not a pressing issue.
