### PR TITLE
Fix installation of sidx_export.h

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -22,6 +22,7 @@ nobase_spatialindex_HEADERS =			spatialindex/SpatialIndex.h \
 								spatialindex/capi/LeafQuery.h \
 								spatialindex/capi/ObjVisitor.h \
 								spatialindex/capi/sidx_api.h \
+								spatialindex/capi/sidx_export.h \
 								spatialindex/capi/sidx_config.h \
 								spatialindex/capi/sidx_impl.h \
 								spatialindex/capi/Utility.h \


### PR DESCRIPTION
Need to add a line for sidx_export.h around here:

https://github.com/libspatialindex/libspatialindex/blob/4536e074ee2146979a5e3d7d77ccc2e7194b7ff4/include/Makefile.am#L25
