### PR TITLE
Add a flush function to each index type

### DIFF
--- a/include/spatialindex/SpatialIndex.h
+++ b/include/spatialindex/SpatialIndex.h
@@ -204,6 +204,7 @@ namespace SpatialIndex
 		virtual void addCommand(ICommand* in, CommandType ct) = 0;
 		virtual bool isIndexValid() = 0;
 		virtual void getStatistics(IStatistics** out) const = 0;
+		virtual void flush() = 0;
 		virtual ~ISpatialIndex() {}
 
 	}; // ISpatialIndex

--- a/src/capi/Index.cc
+++ b/src/capi/Index.cc
@@ -427,5 +427,6 @@ void Index::SetResultSetLimit(int64_t v)
 
 void Index::flush()
 {
+	m_rtree->flush();
 	m_storage->flush();
 }

--- a/src/mvrtree/MVRTree.cc
+++ b/src/mvrtree/MVRTree.cc
@@ -570,6 +570,11 @@ void SpatialIndex::MVRTree::MVRTree::getStatistics(IStatistics** out) const
 	*out = new Statistics(m_stats);
 }
 
+void SpatialIndex::MVRTree::MVRTree::flush()
+{
+	storeHeader();
+}
+
 void SpatialIndex::MVRTree::MVRTree::initNew(Tools::PropertySet& ps)
 {
 	Tools::Variant var;

--- a/src/mvrtree/MVRTree.h
+++ b/src/mvrtree/MVRTree.h
@@ -81,6 +81,7 @@ namespace SpatialIndex
 			virtual void addCommand(ICommand* pCommand, CommandType ct);
 			virtual bool isIndexValid();
 			virtual void getStatistics(IStatistics** out) const;
+			virtual void flush();
 
 		private:
 			void initNew(Tools::PropertySet&);

--- a/src/rtree/RTree.cc
+++ b/src/rtree/RTree.cc
@@ -809,6 +809,11 @@ void SpatialIndex::RTree::RTree::getStatistics(IStatistics** out) const
 	*out = new Statistics(m_stats);
 }
 
+void SpatialIndex::RTree::RTree::flush()
+{
+	storeHeader();
+}
+
 void SpatialIndex::RTree::RTree::initNew(Tools::PropertySet& ps)
 {
 	Tools::Variant var;

--- a/src/rtree/RTree.h
+++ b/src/rtree/RTree.h
@@ -80,6 +80,7 @@ namespace SpatialIndex
 			virtual void addCommand(ICommand* pCommand, CommandType ct);
 			virtual bool isIndexValid();
 			virtual void getStatistics(IStatistics** out) const;
+			virtual void flush();
 
 		private:
 			void initNew(Tools::PropertySet&);

--- a/src/tprtree/TPRTree.cc
+++ b/src/tprtree/TPRTree.cc
@@ -593,6 +593,11 @@ void SpatialIndex::TPRTree::TPRTree::getStatistics(IStatistics** out) const
 	*out = new Statistics(m_stats);
 }
 
+void SpatialIndex::TPRTree::TPRTree::flush()
+{
+	storeHeader();
+}
+
 void SpatialIndex::TPRTree::TPRTree::initNew(Tools::PropertySet& ps)
 {
 	Tools::Variant var;

--- a/src/tprtree/TPRTree.h
+++ b/src/tprtree/TPRTree.h
@@ -79,6 +79,7 @@ namespace SpatialIndex
 			virtual void addCommand(ICommand* pCommand, CommandType ct);
 			virtual bool isIndexValid();
 			virtual void getStatistics(IStatistics** out) const;
+			virtual void flush();
 
 		private:
 			void initNew(Tools::PropertySet&);


### PR DESCRIPTION
Each RTree variant also needs to be able to flush its header to disk on
request so that we can successfully reopen indices.