### PR TITLE
Fix Node::reinsertData selection criteria

### DIFF
--- a/src/rtree/Node.cc
+++ b/src/rtree/Node.cc
@@ -589,15 +589,20 @@ void Node::reinsertData(uint32_t dataLength, byte* pData, Region& mbr, id_type i
 
 	uint32_t cCount;
 
-	for (cCount = 0; cCount < cReinsert; ++cCount)
+    // Keep all but cReinsert nodes
+	for (cCount = 0; cCount < m_capacity + 1 - cReinsert; ++cCount)
 	{
-		reinsert.push_back(v[cCount]->m_index);
+		keep.push_back(v[cCount]->m_index);
 		delete v[cCount];
 	}
 
-	for (cCount = cReinsert; cCount < m_capacity + 1; ++cCount)
+    // Remove cReinsert nodes which will be
+    // reinserted into the tree. Since our array
+    // is already sorted in ascending order this
+    // matches the order suggested in the paper.
+	for (cCount = m_capacity + 1 - cReinsert; cCount < m_capacity + 1; ++cCount)
 	{
-		keep.push_back(v[cCount]->m_index);
+		reinsert.push_back(v[cCount]->m_index);
 		delete v[cCount];
 	}
 


### PR DESCRIPTION

Fix Incorrect R*-tree reinsertion implementation
===

I'm pretty sure that libspatialindex has an incorrect R*-tree implementation
related to the structure optimizations. I'm still working on groking the
algorithm completely so I may be missing a detail.

First I've listed code snippets from the paper's algorithms as well as from
the source to libspatialindex. The end of this writeup describes the bug as
I understand it with a discussion the fix.


The R*-tree paper's "Algorithm Reinsert"
---

This is on page 327 on the copy I'm reading (which is the one linked
from Wikipedia).

http://dbs.mathematik.uni-marburg.de/publications/myPapers/1990/BKSS90.pdf

<pre>
Algorithm Reinsert

RI1 - For all M+l entries of a node N, compute the distance
      between the centers of their rectangles and the center
      of the bounding rectangle of N

RI2 - Sort the entries in decreasing order of their distances
      computed m RI1

RI3 - Remove the first p entries from N and adjust the
      bounding rectangle of N

RI4 - In the sort, defined 111 R12, starting with the maximum
      distance (= far reinsert) or minimum distance (= close
      reinsert), invoke Insert to reinsert the entries
</pre>

Node::reinsertData
---

https://github.com/libspatialindex/libspatialindex/blob/master/src/rtree/Node.cc#L548

This is a fairly close adherence to the algorithm as specified in the R*-tree
paper. I've separated for clarity and commented on deviations from the
algorithm as dictated in the paper.

<h4>RI1</h4>

This is a simple and straightforward step.

<pre>
void Node::reinsertData(uint32_t dataLength, byte* pData, Region& mbr, id_type id, std::vector<uint32_t>& reinsert, std::vector<uint32_t>& keep)
{
	ReinsertEntry** v = new ReinsertEntry*[m_capacity + 1];

	m_pDataLength[m_children] = dataLength;
	m_pData[m_children] = pData;
	m_ptrMBR[m_children] = m_pTree->m_regionPool.acquire();
	*(m_ptrMBR[m_children]) = mbr;
	m_pIdentifier[m_children] = id;

	PointPtr nc = m_pTree->m_pointPool.acquire();
	m_nodeMBR.getCenter(*nc);
	PointPtr c = m_pTree->m_pointPool.acquire();

	for (uint32_t u32Child = 0; u32Child < m_capacity + 1; ++u32Child)
	{
		try
		{
			v[u32Child] = new ReinsertEntry(u32Child, 0.0);
		}
		catch (...)
		{
			for (uint32_t i = 0; i < u32Child; ++i) delete v[i];
			delete[] v;
			throw;
		}

		m_ptrMBR[u32Child]->getCenter(*c);

		// calculate relative distance of every entry from the node MBR (ignore square root.)
		for (uint32_t cDim = 0; cDim < m_nodeMBR.m_dimension; ++cDim)
		{
			double d = nc->m_pCoords[cDim] - c->m_pCoords[cDim];
			v[u32Child]->m_dist += d * d;
		}
	}
</pre>

<h4>RI2</h4>

Notice the comment and how it disagrees with the paper's request for a
sort in decreasing order. I've included the definition of ReinsertEntry
below this code so that we can see that we're not being silly and
reversing the sort by changing the semantics of the compare function.

<pre>
	// sort by increasing order of distances.
	::qsort(v, m_capacity + 1, sizeof(ReinsertEntry*), ReinsertEntry::compareReinsertEntry);
</pre>

<h4>RI3 - RI4</h4>

This is a combination of the last two steps. Technically we're not making
the actual modifications requested here, we're just splitting the child
nodes into two groups and returning them. The actual mutations are handled
in `Node::insertData` here:

https://github.com/libspatialindex/libspatialindex/blob/master/src/rtree/Node.cc#L378

The important point to note though is that the nodes placed into the
reinsertion group are from the front of the sorted array which *does*
follow the algorithm from the paper.

<pre>
	uint32_t cReinsert = static_cast<uint32_t>(std::floor((m_capacity + 1) * m_pTree->m_reinsertFactor));

	uint32_t cCount;

	for (cCount = 0; cCount < cReinsert; ++cCount)
	{
		reinsert.push_back(v[cCount]->m_index);
		delete v[cCount];
	}

	for (cCount = cReinsert; cCount < m_capacity + 1; ++cCount)
	{
		keep.push_back(v[cCount]->m_index);
		delete v[cCount];
	}

	delete[] v;
}
</pre>

ReinsertEntry comparator
---

Included for reference from above.

https://github.com/cloudant/libspatialindex/blob/master/src/rtree/Node.h#L174

<pre>
class ReinsertEntry
{
public:
	uint32_t m_index;
	double m_dist;

	ReinsertEntry(uint32_t index, double dist) : m_index(index), m_dist(dist) {}

	static int compareReinsertEntry(const void* pv1, const void* pv2)
	{
		ReinsertEntry* pe1 = * (ReinsertEntry**) pv1;
		ReinsertEntry* pe2 = * (ReinsertEntry**) pv2;

		if (pe1->m_dist &lt; pe2->m_dist) return -1;
		if (pe1->m_dist > pe2->m_dist) return 1;
		return 0;
	}
}; // ReinsertEntry
</pre>

Discussion
---

First, my understanding of the reinsertion algorithm:

1. Sort the node's children based on distance from the center of each child's
   MBR to the center of the node's enclosing MBR.
2. Remove the `p` *farthest* entries from the center of the node's enclosing
   MBR
3. Insert these entries back into the tree at the appropriate level.

And my understanding of the implementation in libspatialindex

1. Same as the algorithm and what I've stated above
2. Remove the `p` *nearest* entries from the center of the node's enclosing
   MBR
3. Insert these entries back into the tree at the appropriate level (which
   would not unlikely be the same node, though I haven't verified that and
   it'd obviously depend on operation ordering).

The reason for the discrepancy is that libspatialindex sorts its nodes
in ascending order without correctly accounting for that and switching the
end of the array to remove.

However, in RI4 the paper mentions a choice in the order of reinserts by
switching the order in which reinserts are applied. If you reinsert the
nodes nearest first its a close reinsert, and reinserting the farther nodes
first is a far insert. The paper then goes on to say:

<pre>
The experiments have shown that p = 30% of M for leaf nodes
as well as for nonleaf nodes yields the best performance.
Furthermore, for all data files and query files close reinsert
outperforms far reinsert.
</pre>

When I first read this I thought it meant the sort in RI2, however it made
me pause and think because it didn't make sense why removing nodes from the
middle of a node's MBR would be more efficient than removing the outliers.

The conclusion I came to was that the paper is actually only referring to
the nodes to be reinserted. Thus, after we select the farthest-from-center
nodes to reinsert, we then have a choice on which order to reinsert them.

Given that we're already sorting in ascending order we can just go ahead and
push these into the vector to match the suggested order of reinserts.