### PR TITLE
Fix Region::touchesRegion

### DIFF
--- a/src/spatialindex/Region.cc
+++ b/src/spatialindex/Region.cc
@@ -301,13 +301,13 @@ bool Region::touchesRegion(const Region& r) const
 	for (uint32_t i = 0; i < m_dimension; ++i)
 	{
 		if (
-			(m_pLow[i] >= r.m_pLow[i] + std::numeric_limits<double>::epsilon() &&
-			m_pLow[i] <= r.m_pLow[i] - std::numeric_limits<double>::epsilon()) ||
-			(m_pHigh[i] >= r.m_pHigh[i] + std::numeric_limits<double>::epsilon() &&
-			m_pHigh[i] <= r.m_pHigh[i] - std::numeric_limits<double>::epsilon()))
-			return false;
+			(m_pLow[i] >= r.m_pLow[i] - std::numeric_limits<double>::epsilon() &&
+			m_pLow[i] <= r.m_pLow[i] + std::numeric_limits<double>::epsilon()) ||
+			(m_pHigh[i] >= r.m_pHigh[i] - std::numeric_limits<double>::epsilon() &&
+			m_pHigh[i] <= r.m_pHigh[i] + std::numeric_limits<double>::epsilon()))
+			return true;
 	}
-	return true;
+	return false;
 }
 
 


### PR DESCRIPTION
This flips the logic so that we correctly identify if two regions share
a value for a dimension.

Fixes #55