### PR TITLE
Fix adjustTree during R*-tree reinserts

### DIFF
--- a/src/rtree/Index.cc
+++ b/src/rtree/Index.cc
@@ -280,7 +280,7 @@ uint32_t Index::findLeastOverlap(const Region& r) const
 	return ret;
 }
 
-void Index::adjustTree(Node* n, std::stack<id_type>& pathBuffer)
+void Index::adjustTree(Node* n, std::stack<id_type>& pathBuffer, bool force)
 {
 	++(m_pTree->m_stats.m_u64Adjustments);
 
@@ -300,7 +300,7 @@ void Index::adjustTree(Node* n, std::stack<id_type>& pathBuffer)
 
 	*(m_ptrMBR[child]) = n->m_nodeMBR;
 
-	if (bRecompute)
+	if (bRecompute || force)
 	{
 		for (uint32_t cDim = 0; cDim < m_nodeMBR.m_dimension; ++cDim)
 		{
@@ -317,12 +317,12 @@ void Index::adjustTree(Node* n, std::stack<id_type>& pathBuffer)
 
 	m_pTree->writeNode(this);
 
-	if (bRecompute && (! pathBuffer.empty()))
+	if ((bRecompute || force) && (! pathBuffer.empty()))
 	{
 		id_type cParent = pathBuffer.top(); pathBuffer.pop();
 		NodePtr ptrN = m_pTree->readNode(cParent);
 		Index* p = static_cast<Index*>(ptrN.get());
-		p->adjustTree(this, pathBuffer);
+		p->adjustTree(this, pathBuffer, force);
 	}
 }
 

--- a/src/rtree/Index.h
+++ b/src/rtree/Index.h
@@ -47,7 +47,7 @@ namespace SpatialIndex
 			uint32_t findLeastEnlargement(const Region&) const;
 			uint32_t findLeastOverlap(const Region&) const;
 
-			void adjustTree(Node*, std::stack<id_type>&);
+			void adjustTree(Node*, std::stack<id_type>&, bool force = false);
 			void adjustTree(Node*, Node*, std::stack<id_type>&, byte* overflowTable);
 
 			class OverlapEntry

--- a/src/rtree/Node.cc
+++ b/src/rtree/Node.cc
@@ -471,7 +471,7 @@ bool Node::insertData(uint32_t dataLength, byte* pData, Region& mbr, id_type id,
 		id_type cParent = pathBuffer.top(); pathBuffer.pop();
 		NodePtr ptrN = m_pTree->readNode(cParent);
 		Index* p = static_cast<Index*>(ptrN.get());
-		p->adjustTree(this, pathBuffer);
+		p->adjustTree(this, pathBuffer, true);
 
 		for (cIndex = 0; cIndex < lReinsert; ++cIndex)
 		{


### PR DESCRIPTION
This forces an MBR calculation when reinserting entries during an
R*-tree update that would have otherwise required a node split.

Fixes #58