### PR TITLE
Fix RTree::Index::adjustTree

### DIFF
--- a/src/rtree/Index.cc
+++ b/src/rtree/Index.cc
@@ -338,9 +338,11 @@ void Index::adjustTree(Node* n1, Node* n2, std::stack<id_type>& pathBuffer, byte
 	}
 
 	// MBR needs recalculation if either:
-	//   1. the NEW child MBR is not contained.
+	//   1. either child MBR is not contained.
 	//   2. the OLD child MBR is touching.
-	bool bContained = m_nodeMBR.containsRegion(n2->m_nodeMBR);
+	bool bContained1 = m_nodeMBR.containsRegion(n1->m_nodeMBR);
+	bool bContained2 = m_nodeMBR.containsRegion(n2->m_nodeMBR);
+	bool bContained = bContained1 && bContained2;
 	bool bTouches = m_nodeMBR.touchesRegion(*(m_ptrMBR[child]));
 	bool bRecompute = (! bContained || (bTouches && m_pTree->m_bTightMBRs));
 


### PR DESCRIPTION
With R*Tree splits there's no guarantee that the newly added node ends
up in the n2 node passed to adjustTree. As such we have to test both n1
and n2 for containment.