### PR TITLE
Fix RTree deletions

### DIFF
--- a/src/rtree/Leaf.cc
+++ b/src/rtree/Leaf.cc
@@ -109,13 +109,13 @@ void Leaf::split(uint32_t dataLength, byte* pData, Region& mbr, id_type id, Node
 	}
 }
 
-void Leaf::deleteData(id_type id, std::stack<id_type>& pathBuffer)
+void Leaf::deleteData(const Region& mbr, id_type id, std::stack<id_type>& pathBuffer)
 {
 	uint32_t child;
 
 	for (child = 0; child < m_children; ++child)
 	{
-		if (m_pIdentifier[child] == id) break;
+		if (m_pIdentifier[child] == id && mbr == *(m_ptrMBR[child])) break;
 	}
 
 	deleteEntry(child);

--- a/src/rtree/Leaf.h
+++ b/src/rtree/Leaf.h
@@ -44,7 +44,7 @@ namespace SpatialIndex
 
 			virtual void split(uint32_t dataLength, byte* pData, Region& mbr, id_type id, NodePtr& left, NodePtr& right);
 
-			virtual void deleteData(id_type id, std::stack<id_type>& pathBuffer);
+			virtual void deleteData(const Region& mbr, id_type id, std::stack<id_type>& pathBuffer);
 
 			friend class RTree;
 			friend class BulkLoader;

--- a/src/rtree/RTree.cc
+++ b/src/rtree/RTree.cc
@@ -1265,7 +1265,7 @@ bool SpatialIndex::RTree::RTree::deleteData_impl(const Region& mbr, id_type id)
 	if (l.get() != 0)
 	{
 		Leaf* pL = static_cast<Leaf*>(l.get());
-		pL->deleteData(id, pathBuffer);
+		pL->deleteData(mbr, id, pathBuffer);
 		--(m_stats.m_u64Data);
 		return true;
 	}


### PR DESCRIPTION
If a leaf has multiple entries for the same identifier we have to check
that we're deleting the correct MBR.