### PR TITLE
fixed stat use for MSVC to use _stat64 instead to support files large…

### DIFF
--- a/src/storagemanager/DiskStorageManager.cc
+++ b/src/storagemanager/DiskStorageManager.cc
@@ -31,6 +31,10 @@
 // For checking if a file exists - hobu
 #include <sys/stat.h>
 
+#ifdef WIN32
+#define stat _stat64
+#endif
+
 #include <spatialindex/SpatialIndex.h>
 #include "DiskStorageManager.h"
 #include <spatialindex/tools/Tools.h>


### PR DESCRIPTION
…r than 2GB

As I understand the manpage for posix' stat, this is not an issue there as it is obfuscated in the background.

The use of stat should probably be replaced by std::filesystem::exists() as soon as STL of C++17 is widely supported. But this fix does it for now.

Thanks