### PR TITLE
Fix invalid declarations in C API

### DIFF
--- a/include/spatialindex/capi/sidx_api.h
+++ b/include/spatialindex/capi/sidx_api.h
@@ -38,7 +38,7 @@ IDX_C_START
 SIDX_DLL IndexH Index_Create(IndexPropertyH properties);
 
 SIDX_DLL IndexH Index_CreateWithStream( IndexPropertyH properties,
-										int (*readNext)(int64_t *id, double **pMin, double **pMax, uint32_t *nDimension, const uint8_t **pData, size_t *nDataLength)
+										int (*readNext)(int64_t *id, double **pMin, double **pMax, uint32_t *nDimension, const uint8_t **pData, uint32_t *nDataLength)
 									   );
 
 SIDX_DLL void Index_Destroy(IndexH index);
@@ -76,7 +76,7 @@ SIDX_DLL RTError Index_InsertData(	IndexH index,
 									double* pdMax,
 									uint32_t nDimension,
 									const uint8_t* pData,
-									size_t nDataLength);
+									uint32_t nDataLength);
 
 SIDX_C_DLL RTError Index_InsertTPData( IndexH index,
   int64_t id,
@@ -88,7 +88,7 @@ SIDX_C_DLL RTError Index_InsertTPData( IndexH index,
   double tEnd,
   uint32_t nDimension,
   const uint8_t* pData,
-  size_t nDataLength);
+  uint32_t nDataLength);
 
 SIDX_C_DLL RTError Index_InsertMVRData( IndexH index,
 	int64_t id,
@@ -98,7 +98,7 @@ SIDX_C_DLL RTError Index_InsertMVRData( IndexH index,
 	double tEnd,
 	uint32_t nDimension,
 	const uint8_t* pData,
-	size_t nDataLength);
+	uint32_t nDataLength);
 
 SIDX_DLL uint32_t Index_IsValid(IndexH index);
 
@@ -354,8 +354,8 @@ SIDX_DLL int64_t IndexProperty_GetIndexID(IndexPropertyH iprop);
 SIDX_C_DLL void* SIDX_NewBuffer(size_t bytes);
 SIDX_C_DLL void  SIDX_DeleteBuffer(void* buffer);
 
-SIDX_DLL RTError IndexProperty_SetResultSetLimit(IndexPropertyH iprop, uint64_t value);
-SIDX_DLL uint64_t IndexProperty_GetResultSetLimit(IndexPropertyH iprop);
+SIDX_DLL RTError IndexProperty_SetResultSetLimit(IndexPropertyH iprop, int64_t value);
+SIDX_DLL int64_t IndexProperty_GetResultSetLimit(IndexPropertyH iprop);
 
 SIDX_C_DLL char* SIDX_Version();
 

--- a/src/capi/sidx_api.cc
+++ b/src/capi/sidx_api.cc
@@ -30,6 +30,7 @@
 #include <limits>
 #include <cassert>
 #include <cstring>
+#include <spatialindex/capi/sidx_api.h>
 #include <spatialindex/capi/sidx_impl.h>
 
 #ifdef __GNUC__


### PR DESCRIPTION
The declarations in the C API headers use types that don't match those used in the definitions.

It seems that compilation is currently succeeding because the C API headers are not included anywhere during compilation of the shared library.

Third parties are still able to link against these invalid headers and use the C library (the functions have the correct names), but this causes **undefined behaviour at runtime**, (which is how this bug was found..)


In this PR, the C API headers are added to the top of the source file. This allows the compiler to do type checking. The compile errors were then fixed (by altering the headers, not the source)

**Note to other library users**: This means the C API should be considered unsafe. One option would be to vendor the correct headers and compile against those instead.
