### PR TITLE
configure.ac: do not force -O2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ if test "x$enable_debug" = "xyes"; then
 	CXXFLAGS="$CXXFLAGS -g -DDEBUG"
 	AC_MSG_RESULT(checking wether debug information is enabled... yes)
 else
-	CXXFLAGS="$CXXFLAGS -O2 -DNDEBUG"
+	CXXFLAGS="$CXXFLAGS -DNDEBUG"
 	AC_MSG_RESULT(checking wether debug information is enabled... no)
 fi
 


### PR DESCRIPTION
The user may want to provide its own set of optimization flags, and
therefore forcing -O2 should not be done.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>