### PR TITLE
Update introduction.txt

### DIFF
--- a/docs/source/introduction.txt
+++ b/docs/source/introduction.txt
@@ -42,5 +42,7 @@ Features
   node capacity, etc.
 * STR packing / bulk loading.
 
+Warnings
+------------------------------------------------------------------------------
 
-
+* The library is not thread-safe, even for seemingly read-only operations. Queries and updates must be run from within mutexes.


### PR DESCRIPTION
At two separate points in my life I've been bitten by assuming the library was thread-safe under apparently read-only operations, at the cost of several hour's work. In the end the solution was easy: use a mutex.

Looking through the git issues, it seems I'm not the only one who's had this experience. Putting a little notice here (and maybe other places as well?) seems like a low-cost way of heading off this kind of problem.