### PR TITLE
Fix array allocation in Index_GetLeaves.

### DIFF
--- a/src/capi/sidx_api.cc
+++ b/src/capi/sidx_api.cc
@@ -1693,8 +1693,8 @@ SIDX_C_DLL RTError Index_GetLeaves(	IndexH index,
 			(*nLeafSizes)[k] = (uint32_t)ids.size();
 
 			(*nLeafChildIDs)[k] = (int64_t*) malloc( (*nLeafSizes)[k] * sizeof(int64_t));
-			(*pppdMin)[k] = (double*) malloc ( (*nLeafSizes)[k] *  sizeof(double));
-			(*pppdMax)[k] = (double*) malloc ( (*nLeafSizes)[k] *  sizeof(double));
+			(*pppdMin)[k] = (double*) malloc (*nDimension * sizeof(double));
+			(*pppdMax)[k] = (double*) malloc (*nDimension * sizeof(double));
 			for (uint32_t i=0; i< *nDimension; ++i) {
 				(*pppdMin)[k][i] = b->getLow(i);
 				(*pppdMax)[k][i] = b->getHigh(i);


### PR DESCRIPTION
When filling the array, it iterates through `nDimension` elements, but only allocates `nLeafSizes[k]` entries. This causes out-of-bounds access when dimensions are greater than leafs.

This causes a crash in `geopandas/tests/test_sindex.py::TestSeriesSindex::test_point`, though only on 32-bit for some reason (or possibly it's just more likely there.)