### PR TITLE
Cmake support for 'Visual Studio 15 2017 [Win64]' generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,12 @@ SET(SIDX_LIB_SOVERSION "4")
 
 set(SIDX_VERSION_STRING "${SIDX_VERSION_MAJOR}.${SIDX_VERSION_MINOR}.${SIDX_VERSION_PATCH}")
 
+#------------------------------------------------------------------------------
+# libspatialindex general cmake options
+#------------------------------------------------------------------------------
+
+option(SIDX_BUILD_TESTS "Enables integrated test suites" ON)
+
 
 # Name of C++ library
 
@@ -241,5 +247,7 @@ set(SIDX_DATA_DIR ${SIDX_DATA_SUBDIR})
 #------------------------------------------------------------------------------
 
 add_subdirectory(src)
-add_subdirectory(test)
 
+if(SIDX_BUILD_TESTS)
+  add_subdirectory(test)
+endif()

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2018-04-26
+	* Michael Herwig <michael.herwig@hotmail.de> Added cmake support for 'Visual Studio 15 2017 [Win64]' generator (12:32:00)
+
 2014-10-31
 	* Howard Butler <howard@hobu.co> CAPI: revert #40, which could cause inconsistent object lifetime behavior (23:53:04)
 	* Howard Butler <howard@hobu.co> missed a variable substitution on SIDX_LIB_VERSION (21:38:14)

--- a/include/spatialindex/capi/sidx_config.h
+++ b/include/spatialindex/capi/sidx_config.h
@@ -44,6 +44,10 @@
   typedef unsigned __int64 uint64_t;
 #endif
 
+#if _MSC_VER >= 1900
+   #include <cinttypes>
+#endif
+
    #include <windows.h>
    #define STRDUP _strdup
    #include <windows.h>

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(MSVC_VERSION GREATER_EQUAL 1900)
+   add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+endif()
+
 add_subdirectory(gtest-1.7.0)
 include_directories(./gtest-1.7.0/include)
 


### PR DESCRIPTION
I wanted to compile the library using Visual Studio 2017. Therefore i added all necessary adjustments to source code and cmake configuration. Everything is wrapped in specific conditions for MSVC with a version greater or equal 1900.