### PR TITLE
Use tabs as opposed to spaces for consistency.

### DIFF
--- a/src/rtree/RTree.h
+++ b/src/rtree/RTree.h
@@ -99,7 +99,7 @@ namespace SpatialIndex
 
 			void rangeQuery(RangeQueryType type, const IShape& query, IVisitor& v);
 			void selfJoinQuery(id_type id1, id_type id2, const Region& r, IVisitor& vis);
-            void visitSubTree(NodePtr subTree, IVisitor& v);
+			void visitSubTree(NodePtr subTree, IVisitor& v);
 
 			IStorageManager* m_pStorageManager;
 


### PR DESCRIPTION
Stay consistent in the use of tabs as opposed to spaces.