### PR TITLE
Correct findLeastEnlargement method to always return a correct value

### DIFF
--- a/src/rtree/Index.cc
+++ b/src/rtree/Index.cc
@@ -144,7 +144,7 @@ void Index::split(uint32_t dataLength, byte* pData, Region& mbr, id_type id, Nod
 
 uint32_t Index::findLeastEnlargement(const Region& r) const
 {
-	double area = std::numeric_limits<double>::max();
+	double area = std::numeric_limits<double>::infinity();
 	uint32_t best = std::numeric_limits<uint32_t>::max();
 
 	RegionPtr t = m_pTree->m_regionPool.acquire();
@@ -165,7 +165,8 @@ uint32_t Index::findLeastEnlargement(const Region& r) const
 		{
 			// this will rarely happen, so compute best area on the fly only
 			// when necessary.
-			if (a < m_ptrMBR[best]->getArea()) best = cChild;
+			if (enl == std::numeric_limits<double>::infinity()
+			    || a < m_ptrMBR[best]->getArea()) best = cChild;
 		}
 	}
 


### PR DESCRIPTION
This PR correct intend to correct this QGIS issue : https://issues.qgis.org/issues/19579

Computed area is sometimes equal to infinity for all children, so this PR forces the method findLeastEnlargement to return always a valid child.