### PR TITLE
Default gtest to use shared run-time lib

### DIFF
--- a/test/gtest/gtest-1.7.0/CMakeLists.txt
+++ b/test/gtest/gtest-1.7.0/CMakeLists.txt
@@ -14,7 +14,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries (DLLs)." OFF)
 option(
   gtest_force_shared_crt
   "Use shared (DLL) run-time lib even when Google Test is built as static lib."
-  OFF)
+  ON)
 
 option(gtest_build_tests "Build all of gtest's own tests." OFF)
 


### PR DESCRIPTION
Allows MSVC builds without having to manually change any settings