### PR TITLE
Change 'mktemp' to 'mkstemp' in 'Tools'

### DIFF
--- a/src/tools/Tools.cc
+++ b/src/tools/Tools.cc
@@ -1080,7 +1080,7 @@ Tools::TemporaryFile::TemporaryFile()
 
 #else
 	char tmpName[7] = "XXXXXX";
-	if (mktemp(tmpName) == nullptr)
+	if (mkstemp(tmpName) == -1)
 		throw std::ios_base::failure("Tools::TemporaryFile: Cannot create temporary file name.");
 	m_sFile = tmpName;
 #endif


### PR DESCRIPTION
GNU warning about `mktemp` function:

> Warning: Between the time the pathname is constructed and the file is created another process might have created a file with the same name using mktemp, leading to a possible security hole. The implementation generates names which can hardly be predicted, but when opening the file you should use the O_EXCL flag. Using mkstemp is a safe way to avoid this problem.

https://www.gnu.org/software/libc/manual/html_node/Temporary-Files.html