### PR TITLE
Set default python version to python2 in gtest

### DIFF
--- a/test/gtest/gtest-1.7.0/scripts/fuse_gtest_files.py
+++ b/test/gtest/gtest-1.7.0/scripts/fuse_gtest_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2009, Google Inc.
 # All rights reserved.


### PR DESCRIPTION
In some systems, the default python version is 3.