### PR TITLE
Removed deprecated binary_function functions.

### DIFF
--- a/include/spatialindex/MovingRegion.h
+++ b/include/spatialindex/MovingRegion.h
@@ -152,10 +152,6 @@ namespace SpatialIndex
 			uint32_t m_boundary;
 			const MovingRegion* m_to;
 
-			struct ascending: public std::binary_function<CrossPoint&, CrossPoint&, bool>
-			{
-				bool operator()(const CrossPoint& __x, const CrossPoint& __y) const { return __x.m_t > __y.m_t; }
-			};
 		}; // CrossPoint
 
 	public:

--- a/src/mvrtree/MVRTree.h
+++ b/src/mvrtree/MVRTree.h
@@ -181,10 +181,6 @@ namespace SpatialIndex
 				NNEntry(id_type id, IEntry* e, double f) : m_id(id), m_pEntry(e), m_minDist(f) {}
 				~NNEntry() = default;
 
-				struct greater : public std::binary_function<NNEntry*, NNEntry*, bool>
-				{
-					bool operator()(const NNEntry* __x, const NNEntry* __y) const { return __x->m_minDist > __y->m_minDist; }
-				};
 			}; // NNEntry
 
 			class NNComparator : public INearestNeighborComparator

--- a/src/rtree/BulkLoader.h
+++ b/src/rtree/BulkLoader.h
@@ -48,7 +48,7 @@ namespace SpatialIndex
 				void storeToFile(Tools::TemporaryFile& f);
 				void loadFromFile(Tools::TemporaryFile& f);
 
-				struct SortAscending : public std::binary_function<Record* const, Record* const, bool>
+				struct SortAscending
 				{
 					bool operator()(Record* const r1, Record* const r2)
 					{
@@ -80,7 +80,7 @@ namespace SpatialIndex
 			public:
 				PQEntry(Record* r, uint32_t u32Index) : m_r(r), m_u32Index(u32Index) {}
 
-				struct SortAscending : public std::binary_function<const PQEntry&, const PQEntry&, bool>
+				struct SortAscending
 				{
 					bool operator()(const PQEntry& e1, const PQEntry& e2)
 					{

--- a/src/rtree/RTree.cc
+++ b/src/rtree/RTree.cc
@@ -566,7 +566,8 @@ void SpatialIndex::RTree::RTree::nearestNeighborQuery(uint32_t k, const IShape& 
 {
 	if (query.getDimension() != m_dimension) throw Tools::IllegalArgumentException("nearestNeighborQuery: Shape has the wrong number of dimensions.");
 
-	std::priority_queue<NNEntry*, std::vector<NNEntry*>, NNEntry::ascending> queue;
+	auto ascending = [](const NNEntry* lhs, const NNEntry* rhs) { return rhs->m_minDist > lhs->m_minDist; };
+	std::priority_queue<NNEntry*, std::vector<NNEntry*>, decltype(ascending)> queue(ascending);
 
 	queue.push(new NNEntry(m_rootID, nullptr, 0.0));
 

--- a/src/rtree/RTree.h
+++ b/src/rtree/RTree.h
@@ -156,10 +156,6 @@ namespace SpatialIndex
 				NNEntry(id_type id, IEntry* e, double f) : m_id(id), m_pEntry(e), m_minDist(f) {}
 				~NNEntry() = default;
 
-				struct ascending : public std::binary_function<NNEntry*, NNEntry*, bool>
-				{
-					bool operator()(const NNEntry* __x, const NNEntry* __y) const { return __x->m_minDist > __y->m_minDist; }
-				};
 			}; // NNEntry
 
 			class NNComparator : public INearestNeighborComparator

--- a/src/spatialindex/MovingRegion.cc
+++ b/src/spatialindex/MovingRegion.cc
@@ -910,7 +910,8 @@ double MovingRegion::getIntersectingAreaInTime(const IInterval& ivI, const Movin
 
 	MovingRegion x = *this;
 	CrossPoint c;
-	std::priority_queue<CrossPoint, std::vector<CrossPoint>, CrossPoint::ascending> pq;
+	auto ascending = [](CrossPoint& lhs, CrossPoint& rhs) { return lhs.m_t > rhs.m_t; };
+	std::priority_queue < CrossPoint, std::vector<CrossPoint>, decltype(ascending)> pq(ascending);
 
 	// find points of intersection in all dimensions.
 	for (uint32_t i = 0; i < m_dimension; ++i)

--- a/src/tprtree/TPRTree.h
+++ b/src/tprtree/TPRTree.h
@@ -157,10 +157,6 @@ namespace SpatialIndex
 				NNEntry(id_type id, IEntry* e, double f) : m_id(id), m_pEntry(e), m_minDist(f) {}
 				~NNEntry() = default;
 
-				struct ascending : public std::binary_function<NNEntry*, NNEntry*, bool>
-				{
-					bool operator()(const NNEntry* __x, const NNEntry* __y) const { return __x->m_minDist > __y->m_minDist; }
-				};
 			}; // NNEntry
 
 			class NNComparator : public INearestNeighborComparator

--- a/test/mvrtree/Exhaustive.cc
+++ b/test/mvrtree/Exhaustive.cc
@@ -103,10 +103,6 @@ public:
 
 	NNEntry(size_t id, double dist) : m_id(id), m_dist(dist) {}
 
-	struct greater : public binary_function<NNEntry*, NNEntry*, bool>
-	{
-		bool operator()(const NNEntry* __x, const NNEntry* __y) const { return __x->m_dist > __y->m_dist; }
-	};
 };
 
 int main(int argc, char** argv)

--- a/test/rtree/Exhaustive.cc
+++ b/test/rtree/Exhaustive.cc
@@ -84,10 +84,6 @@ public:
 
 	NNEntry(size_t id, double dist) : m_id(id), m_dist(dist) {}
 
-	struct greater : public std::binary_function<NNEntry*, NNEntry*, bool>
-	{
-		bool operator()(const NNEntry* __x, const NNEntry* __y) const { return __x->m_dist > __y->m_dist; }
-	};
 };
 
 int main(int argc, char** argv)
@@ -149,7 +145,8 @@ int main(int argc, char** argv)
 			{
 				Region query = Region(x1, y1, x1, y1);
 
-				std::priority_queue<NNEntry*, std::vector<NNEntry*>, NNEntry::greater > queue;
+				auto greater = [](const NNEntry* lhs, const NNEntry* rhs) { return lhs->m_dist > rhs->m_dist; };
+				std::priority_queue<NNEntry*, std::vector<NNEntry*>, decltype(greater) > queue(greater);
 
 				for (std::multimap<size_t, Region>::iterator it = data.begin(); it != data.end(); it++)
 				{


### PR DESCRIPTION
std::binary_function was deprecated in c++11 and removed in c++17. If you want to keep the old behaviour I would suggest adding the functional include and also force older c++ version in CMakeLists.