### PR TITLE
Exposes Index_Contains_id, Index_Contains_obj endpoints in C-API

### DIFF
--- a/include/spatialindex/capi/sidx_api.h
+++ b/include/spatialindex/capi/sidx_api.h
@@ -129,6 +129,13 @@ SIDX_DLL RTError Index_Intersects_obj(	IndexH index,
 										IndexItemH** items,
 										uint64_t* nResults);
 
+SIDX_C_DLL RTError Index_Contains_obj(  IndexH index,
+                                        double* pdMin,
+                                        double* pdMax,
+                                        uint32_t nDimension,
+                                        IndexItemH** items,
+                                        uint64_t* nResults);
+
 SIDX_C_DLL RTError Index_TPIntersects_id(  IndexH index,
                     double* pdMin,
                     double* pdMax,
@@ -156,6 +163,13 @@ SIDX_DLL RTError Index_Intersects_id(	IndexH index,
 										int64_t** items,
 										uint64_t* nResults);
 
+SIDX_C_DLL RTError Index_Contains_id(IndexH index,
+                                     double *pdMin,
+                                     double *pdMax,
+                                     uint32_t nDimension,
+                                     int64_t **ids,
+                                     uint64_t *nResults);
+
 SIDX_C_DLL RTError Index_TPIntersects_count(	  IndexH index,
                     double* pdMin,
                     double* pdMax,
@@ -179,6 +193,12 @@ SIDX_DLL RTError Index_Intersects_count(	IndexH index,
 										double* pdMax,
 										uint32_t nDimension,
 										uint64_t* nResults);
+
+SIDX_C_DLL RTError Index_Contains_count( IndexH index,
+                                         double* pdMin,
+                                         double* pdMax,
+                                         uint32_t nDimension,
+                                         uint64_t* nResults);
 
 SIDX_C_DLL RTError Index_TPNearestNeighbors_obj(IndexH index,
                       double* pdMin,

--- a/src/capi/sidx_api.cc
+++ b/src/capi/sidx_api.cc
@@ -1142,6 +1142,53 @@ SIDX_C_DLL RTError Index_Intersects_count(	  IndexH index,
 	return RT_None;
 }
 
+SIDX_C_DLL RTError Index_Contains_count( IndexH index,
+                                         double* pdMin,
+                                         double* pdMax,
+                                         uint32_t nDimension,
+                                         uint64_t* nResults)
+{
+    VALIDATE_POINTER1(index, "Index_Contains_count", RT_Failure);
+    Index* idx = reinterpret_cast<Index*>(index);
+    SpatialIndex::Region* r = 0;
+
+    CountVisitor* visitor = new CountVisitor;
+    try {
+        r = new SpatialIndex::Region(pdMin, pdMax, nDimension);
+        idx->index().containsWhatQuery(*r, *visitor);
+
+        *nResults = visitor->GetResultCount();
+
+        delete r;
+        delete visitor;
+
+    } catch (Tools::Exception& e)
+    {
+        Error_PushError(RT_Failure,
+                        e.what().c_str(),
+                        "Index_Contains_count");
+        delete r;
+        delete visitor;
+        return RT_Failure;
+    } catch (std::exception const& e)
+    {
+        Error_PushError(RT_Failure,
+                        e.what(),
+                        "Index_Contains_count");
+        delete r;
+        delete visitor;
+        return RT_Failure;
+    } catch (...) {
+        Error_PushError(RT_Failure,
+                        "Unknown Error",
+                        "Index_Contains_count");
+        delete r;
+        delete visitor;
+        return RT_Failure;
+    }
+    return RT_None;
+}
+
 SIDX_C_DLL RTError Index_SegmentIntersects_obj(  IndexH index,
 										double* pdStartPoint,
 										double* pdEndPoint,

--- a/src/capi/sidx_api.cc
+++ b/src/capi/sidx_api.cc
@@ -834,6 +834,61 @@ SIDX_C_DLL RTError Index_MVRIntersects_id(  IndexH index,
   return RT_None;
 }
 
+
+SIDX_C_DLL RTError Index_Contains_id(IndexH index,
+                                     double *pdMin,
+                                     double *pdMax,
+                                     uint32_t nDimension,
+                                     int64_t **ids,
+                                     uint64_t *nResults)
+{
+    VALIDATE_POINTER1(index, "Index_Intersects_id", RT_Failure);
+    Index* idx = reinterpret_cast<Index*>(index);
+
+    int64_t nResultLimit, nStart;
+    SpatialIndex::Region* r = 0;
+
+    nResultLimit = idx->GetResultSetLimit();
+    nStart = idx->GetResultSetOffset();
+
+    IdVisitor* visitor = new IdVisitor;
+    try {
+        r = new SpatialIndex::Region(pdMin, pdMax, nDimension);
+        idx->index().containsWhatQuery(*r, *visitor);
+
+        Page_ResultSet_Ids(*visitor, ids, nStart, nResultLimit, nResults);
+
+        delete r;
+        delete visitor;
+
+    } catch (Tools::Exception& e)
+    {
+        Error_PushError(RT_Failure,
+                        e.what().c_str(),
+                        "Index_Contains_id");
+        delete r;
+        delete visitor;
+        return RT_Failure;
+    } catch (std::exception const& e)
+    {
+        Error_PushError(RT_Failure,
+                        e.what(),
+                        "Index_Contains_id");
+        delete r;
+        delete visitor;
+        return RT_Failure;
+    } catch (...) {
+        Error_PushError(RT_Failure,
+                        "Unknown Error",
+                        "Index_Contains_id");
+        delete r;
+        delete visitor;
+        return RT_Failure;
+    }
+    return RT_None;
+}
+
+
 SIDX_C_DLL RTError Index_Intersects_id(	  IndexH index,
 										double* pdMin,
 										double* pdMax,

--- a/src/capi/sidx_api.cc
+++ b/src/capi/sidx_api.cc
@@ -722,6 +722,56 @@ SIDX_C_DLL RTError Index_Intersects_obj(  IndexH index,
 	return RT_None;
 }
 
+SIDX_C_DLL RTError Index_Contains_obj(  IndexH index,
+                                          double* pdMin,
+                                          double* pdMax,
+                                          uint32_t nDimension,
+                                          IndexItemH** items,
+                                          uint64_t* nResults)
+{
+    VALIDATE_POINTER1(index, "Index_Contains_obj", RT_Failure);
+    Index* idx = reinterpret_cast<Index*>(index);
+    int64_t nResultLimit, nStart;
+
+    nResultLimit = idx->GetResultSetLimit();
+    nStart = idx->GetResultSetOffset();
+
+    ObjVisitor* visitor = new ObjVisitor;
+    SpatialIndex::Region* r = 0;
+    try {
+        r = new SpatialIndex::Region(pdMin, pdMax, nDimension);
+        idx->index().containsWhatQuery(*r, *visitor);
+
+        Page_ResultSet_Obj(*visitor, items, nStart, nResultLimit, nResults);
+
+        delete r;
+        delete visitor;
+
+    } catch (Tools::Exception& e)
+    {
+        delete r;
+        delete visitor;
+        Error_PushError(RT_Failure,
+                        e.what().c_str(),
+                        "Index_Contains_obj");
+    } catch (std::exception const& e)
+    {
+        delete r;
+        delete visitor;
+        Error_PushError(RT_Failure,
+                        e.what(),
+                        "Index_Contains_obj");
+        delete visitor;
+    } catch (...) {
+        delete r;
+        delete visitor;
+        Error_PushError(RT_Failure,
+                        "Unknown Error",
+                        "Index_Contains_obj");
+    }
+    return RT_None;
+}
+
 SIDX_C_DLL RTError Index_TPIntersects_id(  IndexH index,
                     double* pdMin,
                     double* pdMax,
@@ -842,7 +892,7 @@ SIDX_C_DLL RTError Index_Contains_id(IndexH index,
                                      int64_t **ids,
                                      uint64_t *nResults)
 {
-    VALIDATE_POINTER1(index, "Index_Intersects_id", RT_Failure);
+    VALIDATE_POINTER1(index, "Index_Contains_id", RT_Failure);
     Index* idx = reinterpret_cast<Index*>(index);
 
     int64_t nResultLimit, nStart;

--- a/test/gtest/sidx_api_test.h
+++ b/test/gtest/sidx_api_test.h
@@ -16,7 +16,7 @@ char pszData[5];
 class SidxApiRTreeTest : public testing::Test {
   protected:
     // virtual void SetUp() will be called before each test is run.  You
-    // should define it if you need to initialize the varaibles.
+    // should define it if you need to initialize the variables.
     // Otherwise, this can be skipped.
     void SetUp() override {
       memset(pszData, '\0', sizeof(pszData));
@@ -106,6 +106,34 @@ TEST_F(SidxApiRTreeTest, intersects_bounds) {
   EXPECT_EQ(max[1], pMax[1]);
   free(pMin);
   free(pMax);
+}
+
+TEST_F(SidxApiRTreeTest, contains_obj) {
+    uint64_t nResults;
+    IndexItemH* items;
+    char* pszRes = nullptr;
+    uint64_t len = 0;
+    Index_Contains_obj(idx, min, max, nDims, &items, &nResults);
+    ASSERT_EQ(1, nResults);
+    IndexItem_GetData(items[0], (uint8_t **)&pszRes, &len);
+    EXPECT_EQ(0, strcmp(pszData, pszRes));
+    free(pszRes);
+    Index_DestroyObjResults(items, nResults);
+}
+
+TEST_F(SidxApiRTreeTest, contains_id) {
+    uint64_t nResults;
+    int64_t* items;
+    Index_Contains_id(idx, min, max, nDims, &items, &nResults);
+    EXPECT_EQ(1, nResults);
+    EXPECT_EQ(nId, items[0]);
+    free(items);
+}
+
+TEST_F(SidxApiRTreeTest, contains_count) {
+    uint64_t nResults;
+    Index_Contains_count(idx, min, max, nDims, &nResults);
+    EXPECT_EQ(1, nResults);
 }
 
 #endif // SIDX_API_TEST_H


### PR DESCRIPTION
For some reason, those endpoints were not exposed in C-API previously. Would be great to add'em, right?