### PR TITLE
Ignore gtest signed/unsigned warning in gcc

### DIFF
--- a/test/gtest/gtest-1.7.0/include/gtest/gtest.h
+++ b/test/gtest/gtest-1.7.0/include/gtest/gtest.h
@@ -1445,9 +1445,19 @@ AssertionResult CmpHelperEQ(const char* expected_expression,
                                 // signed/unsigned mismatch.
 #endif
 
+#ifdef __GNUC__
+  _Pragma("GCC diagnostic push")
+  _Pragma("GCC diagnostic ignored \"-Wsign-compare\"")
+#endif
+
   if (expected == actual) {
     return AssertionSuccess();
   }
+
+#ifdef __GNUC__
+      _Pragma("GCC diagnostic pop")
+#endif
+
 
 #ifdef _MSC_VER
 # pragma warning(pop)          // Restores the warning state.


### PR DESCRIPTION
Issue ID: #150 