### PR TITLE
Linux and Macos: fix unknown type name 'size_t' in C API

### DIFF
--- a/include/spatialindex/capi/sidx_api.h
+++ b/include/spatialindex/capi/sidx_api.h
@@ -33,6 +33,8 @@
 
 #include "sidx_config.h"
 
+#include <stddef.h>
+
 IDX_C_START
 
 SIDX_DLL IndexH Index_Create(IndexPropertyH properties);


### PR DESCRIPTION
closes https://github.com/libspatialindex/libspatialindex/issues/181