### PR TITLE
CMakeLists.txt: fix CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,10 @@ INCLUDE (CheckIncludeFiles)
 
 # note we default to RelWithDebInfo mode
 if(NOT MSVC_IDE)
+  if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
     "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel" FORCE)
+  endif()
   message(STATUS "Setting libspatialindex build type - ${CMAKE_BUILD_TYPE}")
 endif()
 


### PR DESCRIPTION
The user is unable to override CMAKE_BUILD_TYPE since version 1.9.1 and
https://github.com/libspatialindex/libspatialindex/commit/e3bcccf38d9f100b59ccf29f7e1cfa174969decd

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>