### PR TITLE
GTest: Workaround Clang 5.0 axp issue with define _POSIX_PATH_MAX 256

### DIFF
--- a/test/gtest/gtest-1.10.0/src/gtest-filepath.cc
+++ b/test/gtest/gtest-1.10.0/src/gtest-filepath.cc
@@ -52,6 +52,10 @@
 #elif defined(_XOPEN_PATH_MAX)
 # define GTEST_PATH_MAX_ _XOPEN_PATH_MAX
 #else
+// Workaround Clang 5.0 axp issue
+#ifndef _POSIX_PATH_MAX
+# define _POSIX_PATH_MAX 256
+#endif // _POSIX_PATH_MAX
 # define GTEST_PATH_MAX_ _POSIX_PATH_MAX
 #endif  // GTEST_OS_WINDOWS
 


### PR DESCRIPTION
This PR addresses an error from #192 for the axp build with Linux Clang 5:
```
...
Scanning dependencies of target gtest
[ 94%] Building CXX object test/gtest/gtest-1.10.0/CMakeFiles/gtest.dir/src/gtest-all.cc.o
In file included from /home/vsts/work/1/s/test/gtest/gtest-1.10.0/src/gtest-all.cc:43:
/home/vsts/work/1/s/test/gtest/gtest-1.10.0/src/gtest-filepath.cc:104:12: error: use of undeclared identifier '_POSIX_PATH_MAX'; did you mean '_PC_PATH_MAX'?
  char cwd[GTEST_PATH_MAX_ + 1] = { '\0' };
           ^~~~~~~~~~~~~~~
           _PC_PATH_MAX
/home/vsts/work/1/s/test/gtest/gtest-1.10.0/src/gtest-filepath.cc:55:26: note: expanded from macro 'GTEST_PATH_MAX_'
# define GTEST_PATH_MAX_ _POSIX_PATH_MAX
                         ^
/usr/include/x86_64-linux-gnu/bits/confname.h:34:5: note: '_PC_PATH_MAX' declared here
    _PC_PATH_MAX,
    ^
1 error generated.
test/gtest/gtest-1.10.0/CMakeFiles/gtest.dir/build.make:79: recipe for target 'test/gtest/gtest-1.10.0/CMakeFiles/gtest.dir/src/gtest-all.cc.o' failed
make[2]: *** [test/gtest/gtest-1.10.0/CMakeFiles/gtest.dir/src/gtest-all.cc.o] Error 1
CMakeFiles/Makefile2:717: recipe for target 'test/gtest/gtest-1.10.0/CMakeFiles/gtest.dir/all' failed
Makefile:179: recipe for target 'all' failed
```
this error is from some unknown external changes outside any libspatialindex efforts.

The "fix" in this PR is to `test/gtest/gtest-1.10.0/src/gtest-filepath.cc` which sets `_POSIX_PATH_MAX` to 256, as defined by [libc](https://www.gnu.org/software/libc/manual/html_node/File-Minimums.html).