### PR TITLE
azp: verbose builds, specify CC (for GTest), osx outsource build

### DIFF
--- a/scripts/azp/linux.yml
+++ b/scripts/azp/linux.yml
@@ -8,59 +8,72 @@ jobs:
     strategy:
       matrix:
         GCC 8:
+          CC: gcc-8
           CXXSTD: 11, 14, 17, 20
           CXX: g++-8
           PACKAGES: g++-8
         GCC 7:
+          CC: gcc-7
           CXXSTD: 11, 14, 17
           CXX: g++-7
           PACKAGES: g++-7
         GCC 6:
+          CC: gcc-6
           CXXSTD: 11, 14
           CXX: g++-6
           PACKAGES: g++-6
         GCC 5:
+          CC: gcc-5
           CXXSTD: 11
           CXX: g++-5
           PACKAGES: g++-5
         GCC 4.9:
+          CC: gcc-4.9
           CXXSTD: 11
           CXX: g++-4.9
           PACKAGES: g++-4.9
         GCC 4.8:
+          CC: gcc-4.8
           CXXSTD: 11
           CXX: g++-4.8
           PACKAGES: g++-4.8
         Clang 8:
+          CC: clang-8
           CXXSTD: 11, 14, 17, 20
           CXX: clang++-8
           PACKAGES: clang-8
           LLVM_REPO: llvm-toolchain-xenial-8
         Clang 7:
+          CC: clang-7
           CXXSTD: 14, 17, 20
           CXX: clang++-7
           PACKAGES: clang-7
           LLVM_REPO: llvm-toolchain-xenial-7
         Clang 6:
+          CC: clang-6.0
           CXXSTD: 14, 17, 20
           CXX: clang++-6.0
           PACKAGES: clang-6.0
           LLVM_REPO: llvm-toolchain-xenial-6.0
         Clang 5:
+          CC: clang-5.0
           CXXSTD: 11, 14, 17
           PACKAGES: clang-5.0
           CXX: clang++-5.0
           LLVM_REPO: llvm-toolchain-xenial-5.0
         Clang 4:
+          CC: clang-4.0
           CXXSTD: 11, 14
           CXX: clang++-4.0
           PACKAGES: clang-4.0
           LLVM_REPO: llvm-toolchain-xenial-4.0
         Clang 3.9:
+          CC: clang-3.9
           CXXSTD: 11, 14
           CXX: clang++-3.9
           PACKAGES: clang-3.9
         Clang 3.8:
+          CC: clang-3.8
           CXX: clang++-3.8
           CXXSTD: 11, 14
           PACKAGES: clang-3.8
@@ -82,7 +95,7 @@ jobs:
         cd build.cxx11
         cmake --version
         cmake -DCMAKE_CXX_STANDARD=11 -DSIDX_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
-        cmake --build . --config $BUILD_TYPE
+        VERBOSE=1 make
         pushd ..
         export PATH=$PATH:`pwd`/build.cxx11/bin
         ./scripts/azp/linux-test.sh
@@ -95,8 +108,8 @@ jobs:
         cd build.cxx14
         cmake --version
         cmake -DCMAKE_CXX_STANDARD=14 -DSIDX_BUILD_TESTS=ON  -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
-        cmake --build . --config $BUILD_TYPE
-        ctest -V --output-on-failure -C $BUILD_TYPE
+        VERBOSE=1 make
+        ctest -V --output-on-failure
       displayName: 'Build C++14'
       condition: contains(variables['CXXSTD'], '14')
     - script: |
@@ -105,8 +118,8 @@ jobs:
         cd build.cxx17
         cmake --version
         cmake -DCMAKE_CXX_STANDARD=17 -DSIDX_BUILD_TESTS=ON  -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
-        cmake --build . --config $BUILD_TYPE
-        ctest -V --output-on-failure -C $BUILD_TYPE
+        VERBOSE=1 make
+        ctest -V --output-on-failure
       displayName: 'Build C++17'
       condition: contains(variables['CXXSTD'], '17')
     - script: |
@@ -115,8 +128,8 @@ jobs:
         cd build.cxx20
         cmake --version
         cmake -DCMAKE_CXX_STANDARD=20 -DSIDX_BUILD_TESTS=ON  -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
-        cmake --build . --config $BUILD_TYPE
-        ctest -V --output-on-failure -C $BUILD_TYPE
+        VERBOSE=1 make
+        ctest -V --output-on-failure
       displayName: 'Build C++20'
       condition: contains(variables['CXXSTD'], '20')
 

--- a/scripts/azp/osx.yml
+++ b/scripts/azp/osx.yml
@@ -7,14 +7,19 @@ jobs:
   timeoutInMinutes: 360
   steps:
   - script: |
-      cmake .  -DSIDX_BUILD_TESTS=ON
+      mkdir build
+      cd build
+      cmake -DSIDX_BUILD_TESTS=ON ..
     displayName: 'CMake'
   - script: |
-      make
+      cd build
+      VERBOSE=1 make
     displayName: 'Build'
   - script: |
-      make test
+      cd build
+      ctest -V --output-on-failure
     displayName: 'Test'
   - script: |
+      cd build
       make dist
     displayName: 'Dist'

--- a/scripts/azp/win.yml
+++ b/scripts/azp/win.yml
@@ -45,7 +45,7 @@ jobs:
         echo %PATH%
         set CC=cl.exe
         set CXX=cl.exe
-        ninja
+        ninja -v
       displayName: 'Build'
     - script: |
         ECHO ON


### PR DESCRIPTION
This PR allows more verbose azp builds, to show commands used to build objects, which helps to see flags and options used with compilers.

C compilers are not required for libspatialindex, but are required for GTest, so add CC to job matrix for consistency.

The osx build had used an in-source build, which are generally not recommended.

And last remark, the Linux builds don't require build configuration (`-C`) for build and test steps, as these use the default "Unix Makefiles" generator.