### PR TITLE
CMake: modern formatting and features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,51 +1,51 @@
 #
-# top-level CMake configuration file for PDAL
+# top-level CMake configuration file for libspatialindex
 #
-# (based originally on the libLAS files copyright Mateusz Loskot)
+# (based originally on the PDAL and libLAS files copyright Mateusz Loskot)
 
-SET(MSVC_INCREMENTAL_DEFAULT OFF)
-cmake_minimum_required(VERSION 3.5.0)
-project(spatialindex)
-
-#------------------------------------------------------------------------------
-# internal cmake settings
-#------------------------------------------------------------------------------
-
-set(CMAKE_COLOR_MAKEFILE ON)
-
-# C++11 required
-set (CMAKE_CXX_STANDARD 11)
-
-# Allow advanced users to generate Makefiles printing detailed commands
-mark_as_advanced(CMAKE_VERBOSE_MAKEFILE)
-
-# Path to additional CMake modules
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
-
-cmake_policy(SET CMP0054 NEW) # Make string comparison behave like you'd expect
-
-if (WIN32)
-    if(${CMAKE_VERSION} VERSION_GREATER "3.14.5")
-        cmake_policy(SET CMP0092 NEW) # don't put /w3 in flags
-    endif()
-endif()
-
-if (APPLE)
-	set(CMAKE_MACOSX_RPATH ON)
-endif (APPLE)
+cmake_minimum_required(VERSION 3.5)
 
 #------------------------------------------------------------------------------
 # libspatialindex general settings
 #------------------------------------------------------------------------------
 
-SET(SIDX_VERSION_MAJOR "1")
-SET(SIDX_VERSION_MINOR "9")
-SET(SIDX_VERSION_PATCH "3")
-SET(SIDX_LIB_VERSION "6.1.1")
-SET(SIDX_LIB_SOVERSION "6")
+set(SIDX_VERSION_MAJOR "1")
+set(SIDX_VERSION_MINOR "9")
+set(SIDX_VERSION_PATCH "3")
+set(SIDX_VERSION_STRING
+  "${SIDX_VERSION_MAJOR}.${SIDX_VERSION_MINOR}.${SIDX_VERSION_PATCH}")
+set(SIDX_LIB_VERSION "6.1.1")
+set(SIDX_LIB_SOVERSION "6")
 
+# disable incremental linker
+set(MSVC_INCREMENTAL_DEFAULT NO)
 
-set(SIDX_VERSION_STRING "${SIDX_VERSION_MAJOR}.${SIDX_VERSION_MINOR}.${SIDX_VERSION_PATCH}")
+project(spatialindex
+  VERSION ${SIDX_VERSION_STRING}
+  LANGUAGES CXX
+)
+
+message(STATUS
+  "Configuring CMake ${CMAKE_VERSION} to build spatialindex ${PROJECT_VERSION}")
+
+#------------------------------------------------------------------------------
+# internal cmake settings
+#------------------------------------------------------------------------------
+
+# Allow advanced users to generate Makefiles printing detailed commands
+mark_as_advanced(CMAKE_VERBOSE_MAKEFILE)
+
+# Only interpret if() arguments as variables or keywords when unquoted
+cmake_policy(SET CMP0054 NEW)
+
+if(WIN32 AND NOT CMAKE_VERSION VERSION_LESS "3.15")
+  # MSVC warning flags are not in CMAKE_<LANG>_FLAGS by default
+  cmake_policy(SET CMP0092 NEW)
+endif()
+
+if(APPLE)
+  set(CMAKE_MACOSX_RPATH ON)
+endif()
 
 #------------------------------------------------------------------------------
 # libspatialindex general cmake options
@@ -54,28 +54,30 @@ set(SIDX_VERSION_STRING "${SIDX_VERSION_MAJOR}.${SIDX_VERSION_MINOR}.${SIDX_VERS
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(SIDX_BUILD_TESTS "Enables integrated test suites" OFF)
 
+# C++11 required, overridable by user
+set(CMAKE_CXX_STANDARD 11
+  CACHE STRING "C++ standard version to use (default is 11)")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Name of C++ library
-
 set(SIDX_LIB_NAME spatialindex)
 set(SIDX_C_LIB_NAME spatialindex_c)
 
-if(WIN32)
-  if (MSVC)
-	if( CMAKE_SIZEOF_VOID_P EQUAL 8 )
-		set( SIDX_LIB_NAME "spatialindex-64" )
-		set( SIDX_C_LIB_NAME "spatialindex_c-64" )
-	else( CMAKE_SIZEOF_VOID_P EQUAL 8 )
-		set( SIDX_LIB_NAME "spatialindex-32"  )
-		set( SIDX_C_LIB_NAME "spatialindex_c-32"  )
-	endif( CMAKE_SIZEOF_VOID_P EQUAL 8 )
+if(WIN32 AND MSVC)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(SIDX_LIB_NAME "${SIDX_LIB_NAME}-64")
+    set(SIDX_C_LIB_NAME "${SIDX_C_LIB_NAME}-64")
+  else()
+    set(SIDX_LIB_NAME "${SIDX_LIB_NAME}-32")
+    set(SIDX_C_LIB_NAME "${SIDX_C_LIB_NAME}-32")
   endif()
 endif()
 
 
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 
-include (CheckFunctionExists)
+include(CheckFunctionExists)
 
 check_function_exists(srand48 HAVE_SRAND48)
 check_function_exists(gettimeofday HAVE_GETTIMEOFDAY)
@@ -84,7 +86,7 @@ check_function_exists(memcpy HAVE_MEMCPY)
 check_function_exists(bcopy HAVE_BCOPY)
 
 
-INCLUDE (CheckIncludeFiles)
+include(CheckIncludeFiles)
 
 
 #------------------------------------------------------------------------------
@@ -95,9 +97,11 @@ INCLUDE (CheckIncludeFiles)
 if(NOT MSVC_IDE)
   if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
-    "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel" FORCE)
+    "Choose the type of build, options are: \
+None Debug Release RelWithDebInfo MinSizeRel" FORCE)
   endif()
-  message(STATUS "Setting libspatialindex build type - ${CMAKE_BUILD_TYPE}")
+  message(STATUS
+    "Setting libspatialindex build type - ${CMAKE_BUILD_TYPE}")
 endif()
 
 set(SIDX_BUILD_TYPE ${CMAKE_BUILD_TYPE})
@@ -119,20 +123,28 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${SIDX_BUILD_OUTPUT_DIRECTORY})
 # Platform and compiler specific settings
 #------------------------------------------------------------------------------
 
-if(NOT WIN32)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
+    CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # Recommended C++ compilation flags
   set(SIDX_COMMON_CXX_FLAGS
-    "-pedantic -Wall -Wpointer-arith -Wcast-align -Wcast-qual  -Wredundant-decls -Wno-long-long")
-endif(NOT WIN32)
+    -pedantic
+    -Wall
+    -Wpointer-arith
+    -Wcast-align
+    -Wcast-qual
+    -Wredundant-decls
+    -Wno-long-long
+  )
+endif()
 
-if (APPLE)
+if(APPLE)
   set(SO_EXT dylib)
   set(CMAKE_FIND_FRAMEWORK "LAST")
 elseif(WIN32)
   set(SO_EXT dll)
 else()
   set(SO_EXT so)
-endif(APPLE)
+endif()
 
 
 enable_testing()
@@ -146,7 +158,7 @@ if(WIN32)
   set(DEFAULT_DATA_SUBDIR .)
   set(DEFAULT_INCLUDE_SUBDIR include)
 
-  if (MSVC)
+  if(MSVC)
     set(DEFAULT_BIN_SUBDIR bin)
   else()
     set(DEFAULT_BIN_SUBDIR .)
@@ -191,7 +203,7 @@ if(SIDX_BUILD_TESTS)
 endif()
 
 #------------------------------------------------------------------------------
-# CPACK controls
+# CPack controls
 #------------------------------------------------------------------------------
 
 
@@ -222,44 +234,48 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/libspatialindexConfigVersion.cmake
   DESTINATION ${LIB_INSTALL_DIR}/cmake/libspatialindex)
 
-SET(CPACK_PACKAGE_VERSION_MAJOR ${SIDX_VERSION_MAJOR})
-SET(CPACK_PACKAGE_VERSION_MINOR ${SIDX_VERSION_MINOR})
-SET(CPACK_PACKAGE_VERSION_PATCH ${SIDX_VERSION_MINOR})
-SET(CPACK_PACKAGE_NAME "libspatialindex")
+set(CPACK_PACKAGE_VERSION_MAJOR ${SIDX_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${SIDX_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${SIDX_VERSION_MINOR})
+set(CPACK_PACKAGE_NAME "libspatialindex")
 
-SET(CPACK_SOURCE_GENERATOR "TBZ2;TGZ")
-SET(CPACK_PACKAGE_VENDOR "libspatialindex Development Team")
-SET(CPACK_RESOURCE_FILE_LICENSE    "${PROJECT_SOURCE_DIR}/COPYING")
+set(CPACK_SOURCE_GENERATOR "TBZ2;TGZ")
+set(CPACK_PACKAGE_VENDOR "libspatialindex Development Team")
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/COPYING")
 
 set(CPACK_SOURCE_PACKAGE_FILE_NAME
     "${CMAKE_PROJECT_NAME}-src-${SIDX_VERSION_STRING}")
 
 set(CPACK_SOURCE_IGNORE_FILES
-"/\\\\.gitattributes;/\\\\.vagrant;/\\\\.DS_Store;/CVS/;/\\\\.git/;\\\\.swp$;~$;\\\\.\\\\#;/\\\\#")
-
-list(APPEND CPACK_SOURCE_IGNORE_FILES "CMakeScripts/")
-list(APPEND CPACK_SOURCE_IGNORE_FILES "_CPack_Packages")
-list(APPEND CPACK_SOURCE_IGNORE_FILES "cmake_install.cmake")
-list(APPEND CPACK_SOURCE_IGNORE_FILES "/bin/")
-list(APPEND CPACK_SOURCE_IGNORE_FILES "/scripts/")
-list(APPEND CPACK_SOURCE_IGNORE_FILES "/azure-pipelines.yml")
-list(APPEND CPACK_SOURCE_IGNORE_FILES ".gitignore")
-list(APPEND CPACK_SOURCE_IGNORE_FILES ".ninja*")
-list(APPEND CPACK_SOURCE_IGNORE_FILES "HOWTORELEASE.txt")
-
-list(APPEND CPACK_SOURCE_IGNORE_FILES "README")
-list(APPEND CPACK_SOURCE_IGNORE_FILES "build/")
-
-list(APPEND CPACK_SOURCE_IGNORE_FILES "CMakeFiles")
-list(APPEND CPACK_SOURCE_IGNORE_FILES "CTestTestfile.cmake")
-list(APPEND CPACK_SOURCE_IGNORE_FILES "/docs/build/")
-list(APPEND CPACK_SOURCE_IGNORE_FILES "/doc/presentations/")
-list(APPEND CPACK_SOURCE_IGNORE_FILES "package-release.sh")
-list(APPEND CPACK_SOURCE_IGNORE_FILES "docker-package.sh")
-
-list(APPEND CPACK_SOURCE_IGNORE_FILES ".gz2")
-
-list(APPEND CPACK_SOURCE_IGNORE_FILES ".bz2")
+  "/\\\\.gitattributes"
+  "/\\\\.vagrant"
+  "/\\\\.DS_Store"
+  "/CVS/"
+  "/\\\\.git/"
+  "\\\\.swp$"
+  "~$"
+  "\\\\.\\\\#"
+  "/\\\\#"
+  "CMakeScripts/"
+  "_CPack_Packages"
+  "cmake_install.cmake"
+  "/bin/"
+  "/scripts/"
+  "/azure-pipelines.yml"
+  ".gitignore"
+  ".ninja*"
+  "HOWTORELEASE.txt"
+  "README"
+  "build/"
+  "CMakeFiles"
+  "CTestTestfile.cmake"
+  "/docs/build/"
+  "/doc/presentations/"
+  "package-release.sh"
+  "docker-package.sh"
+  ".gz"
+  ".bz2"
+)
 
 include(CPack)
 add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ set(SIDX_BASE_HPP
   "${SIDX_HEADERS_DIR}/TPRTree.h"
   "${SIDX_HEADERS_DIR}/Version.h"
 )
-list (APPEND SIDX_HPP ${SIDX_BASE_HPP} )
+list(APPEND SIDX_HPP ${SIDX_BASE_HPP})
 
 set(SIDX_CAPI_HPP
   "${SIDX_HEADERS_CAPI_DIR}/BoundsQuery.h"
@@ -56,7 +56,7 @@ set(SIDX_CAPI_HPP
   "${SIDX_HEADERS_CAPI_DIR}/sidx_impl.h"
   "${SIDX_HEADERS_CAPI_DIR}/Utility.h"
 )
-list (APPEND SIDX_HPP ${SIDX_CAPI_HPP} )
+list(APPEND SIDX_HPP ${SIDX_CAPI_HPP})
 
 set(SIDX_CAPI_CPP
   "${SIDX_CAPI_DIR}/BoundsQuery.cc"
@@ -71,7 +71,7 @@ set(SIDX_CAPI_CPP
   "${SIDX_CAPI_DIR}/sidx_api.cc"
   "${SIDX_CAPI_DIR}/Utility.cc"
 )
-list (APPEND SIDX_CPP ${SIDX_CAPI_CPP} )
+list(APPEND SIDX_CPP ${SIDX_CAPI_CPP})
 
 set(SIDX_SPATIALINDEX_CPP
   "${SIDX_SRC_DIR}/spatialindex/LineSegment.cc"
@@ -83,7 +83,7 @@ set(SIDX_SPATIALINDEX_CPP
   "${SIDX_SRC_DIR}/spatialindex/TimePoint.cc"
   "${SIDX_SRC_DIR}/spatialindex/TimeRegion.cc"
 )
-list (APPEND SIDX_CPP ${SIDX_SPATIALINDEX_CPP} )
+list(APPEND SIDX_CPP ${SIDX_SPATIALINDEX_CPP})
 
 set(SIDX_MVRTREE_CPP
   "${SIDX_SRC_DIR}/mvrtree/Index.cc"
@@ -98,7 +98,7 @@ set(SIDX_MVRTREE_CPP
   "${SIDX_SRC_DIR}/mvrtree/Statistics.cc"
   "${SIDX_SRC_DIR}/mvrtree/Statistics.h"
 )
-list (APPEND SIDX_CPP ${SIDX_MVRTREE_CPP})
+list(APPEND SIDX_CPP ${SIDX_MVRTREE_CPP})
 
 set(SIDX_RTREE_CPP
   "${SIDX_SRC_DIR}/rtree/BulkLoader.cc"
@@ -115,7 +115,7 @@ set(SIDX_RTREE_CPP
   "${SIDX_SRC_DIR}/rtree/Statistics.cc"
   "${SIDX_SRC_DIR}/rtree/Statistics.h"
 )
-list (APPEND SIDX_CPP ${SIDX_RTREE_CPP})
+list(APPEND SIDX_CPP ${SIDX_RTREE_CPP})
 
 set(SIDX_STORAGEMANAGER_CPP
   "${SIDX_SRC_DIR}/storagemanager/Buffer.cc"
@@ -126,11 +126,11 @@ set(SIDX_STORAGEMANAGER_CPP
   "${SIDX_SRC_DIR}/storagemanager/RandomEvictionsBuffer.cc"
   "${SIDX_SRC_DIR}/storagemanager/RandomEvictionsBuffer.h"
 )
-list (APPEND SIDX_CPP ${SIDX_STORAGEMANAGER_CPP})
+list(APPEND SIDX_CPP ${SIDX_STORAGEMANAGER_CPP})
 
-set(SIDX_RAND48 )
+set(SIDX_RAND48)
 
-if (NOT HAVE_SRAND48)
+if(NOT HAVE_SRAND48)
     set(SIDX_RAND48 "${SIDX_SRC_DIR}/tools/rand48.cc")
 endif()
 
@@ -138,7 +138,7 @@ set(SIDX_TOOLS_CPP
   ${SIDX_RAND48}
   "${SIDX_SRC_DIR}/tools/Tools.cc"
 )
-list (APPEND SIDX_CPP ${SIDX_TOOLS_CPP})
+list(APPEND SIDX_CPP ${SIDX_TOOLS_CPP})
 
 set(SIDX_TOOLS_CPP
   "${SIDX_SRC_DIR}/tprtree/Index.cc"
@@ -153,7 +153,7 @@ set(SIDX_TOOLS_CPP
   "${SIDX_SRC_DIR}/tprtree/TPRTree.cc"
   "${SIDX_SRC_DIR}/tprtree/TPRTree.h"
 )
-list (APPEND SIDX_CPP ${SIDX_TOOLS_CPP} )
+list(APPEND SIDX_CPP ${SIDX_TOOLS_CPP})
 #
 # Group source files for IDE source explorers (e.g. Visual Studio)
 #
@@ -170,7 +170,6 @@ source_group("C API Source Files" FILES ${SIDX_CAPI_CPP})
 # Standard include directory of SIDX library
 include_directories(../include)
 
-set (APPS_CPP_DEPENDENCIES "${SIDX_LIB_NAME}" CACHE INTERNAL "libraries to link")
 
 ###############################################################################
 # Targets settings
@@ -179,93 +178,84 @@ set(SIDX_SOURCES
   ${SIDX_HPP}
   ${SIDX_CPP})
 
-# NOTE:
-# This hack is required to correctly link static into shared library.
-# Such practice is not recommended as not portable, instead each library,
-# static and shared should be built from sources separately.
-#if(UNIX)
-#  add_definitions("-fPIC")
-#endif()
+add_library(spatialindex ${SIDX_SOURCES})
 
+add_library(spatialindex_c ${SIDX_CAPI_CPP})
 
-add_library(${SIDX_LIB_NAME} ${SIDX_SOURCES})
+target_link_libraries(spatialindex_c spatialindex)
 
-add_library(${SIDX_C_LIB_NAME} ${SIDX_CAPI_CPP})
+set_property(TARGET spatialindex PROPERTY OUTPUT_NAME ${SIDX_LIB_NAME})
+set_property(TARGET spatialindex_c PROPERTY OUTPUT_NAME ${SIDX_C_LIB_NAME})
 
-target_link_libraries(${SIDX_C_LIB_NAME}
-  ${SIDX_LIB_NAME}
+set_target_properties(spatialindex spatialindex_c PROPERTIES
+  VERSION ${SIDX_LIB_VERSION}
+  SOVERSION ${SIDX_LIB_SOVERSION}
+  # disable the <libname>_EXPORTS
+  DEFINE_SYMBOL ""
 )
 
-set_target_properties(${SIDX_LIB_NAME}
-    PROPERTIES VERSION "${SIDX_LIB_VERSION}"
-               SOVERSION "${SIDX_LIB_SOVERSION}"  )
+target_compile_options(spatialindex
+  PRIVATE ${SIDX_COMMON_CXX_FLAGS})
 
-set_target_properties(${SIDX_C_LIB_NAME}
-    PROPERTIES VERSION "${SIDX_LIB_VERSION}"
-               SOVERSION "${SIDX_LIB_SOVERSION}" )
+target_compile_options(spatialindex_c
+  PRIVATE ${SIDX_COMMON_CXX_FLAGS})
 
 if(MSVC)
-    target_compile_options(${SIDX_LIB_NAME} PRIVATE "/wd4068")
-    target_compile_options(${SIDX_C_LIB_NAME} PRIVATE "/wd4068")
+  target_compile_options(spatialindex PRIVATE /wd4068)
+  target_compile_options(spatialindex_c PRIVATE /wd4068)
 
-    target_compile_definitions(${SIDX_C_LIB_NAME} PRIVATE "-DSIDX_DLL_EXPORT=1")
-    target_compile_definitions(${SIDX_LIB_NAME} PRIVATE "-DSIDX_DLL_EXPORT=1")
-    if (NOT WITH_STATIC_SIDX)
-        target_compile_definitions(${SIDX_LIB_NAME} PRIVATE "-DSIDX_DLL_IMPORT=1")
-        target_compile_definitions(${SIDX_C_LIB_NAME} PRIVATE "-DSIDX_DLL_IMPORT=1")
-    endif()
+  target_compile_definitions(spatialindex_c PRIVATE -DSIDX_DLL_EXPORT=1)
+  target_compile_definitions(spatialindex PRIVATE -DSIDX_DLL_EXPORT=1)
+  if(NOT WITH_STATIC_SIDX)
+    target_compile_definitions(spatialindex PRIVATE -DSIDX_DLL_IMPORT=1)
+    target_compile_definitions(spatialindex_c PRIVATE -DSIDX_DLL_IMPORT=1)
+  endif()
 endif()
 
-if (HAVE_SRAND48)
-    target_compile_definitions(${SIDX_LIB_NAME} PRIVATE -DHAVE_SRAND48=1)
+if(HAVE_SRAND48)
+  target_compile_definitions(spatialindex PRIVATE -DHAVE_SRAND48=1)
 endif()
 
-if (HAVE_GETTIMEOFDAY)
-    target_compile_definitions(${SIDX_LIB_NAME} PRIVATE -DHAVE_GETTIMEOFDAY=1)
+if(HAVE_GETTIMEOFDAY)
+  target_compile_definitions(spatialindex PRIVATE -DHAVE_GETTIMEOFDAY=1)
 endif()
 
-if (HAVE_BZERO)
-    target_compile_definitions(${SIDX_LIB_NAME} PRIVATE -DHAVE_BZERO=1)
+if(HAVE_BZERO)
+  target_compile_definitions(spatialindex PRIVATE -DHAVE_BZERO=1)
 endif()
 
-if (HAVE_MEMSET)
-    target_compile_definitions(${SIDX_LIB_NAME} PRIVATE -DHAVE_MEMSET=1)
+if(HAVE_MEMSET)
+  target_compile_definitions(spatialindex PRIVATE -DHAVE_MEMSET=1)
 endif()
 
-if (HAVE_MEMCPY)
-    target_compile_definitions(${SIDX_LIB_NAME} PRIVATE -DHAVE_MEMCPY=1)
+if(HAVE_MEMCPY)
+  target_compile_definitions(spatialindex PRIVATE -DHAVE_MEMCPY=1)
 endif()
 
-if (HAVE_BCOPY)
-    target_compile_definitions(${SIDX_LIB_NAME} PRIVATE -DHAVE_BCOPY=1)
+if(HAVE_BCOPY)
+  target_compile_definitions(spatialindex PRIVATE -DHAVE_BCOPY=1)
 endif()
 
 
 
-if (APPLE)
-  set_target_properties(
-    ${SIDX_LIB_NAME}
-    PROPERTIES
-    INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib" BUILD_WITH_INSTALL_RPATH OFF)
-
-  set_target_properties(
-    ${SIDX_C_LIB_NAME}
-    PROPERTIES
-    INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib" BUILD_WITH_INSTALL_RPATH OFF)
+if(APPLE)
+  set_target_properties(spatialindex spatialindex_c PROPERTIES
+    INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
+  )
 endif()
 
 ###############################################################################
 # Targets installation
 
-install(TARGETS ${SIDX_LIB_NAME} ${SIDX_C_LIB_NAME}
-	EXPORT libspatialindexTargets
-	RUNTIME DESTINATION ${SIDX_BIN_DIR}
-	LIBRARY DESTINATION ${SIDX_LIB_DIR}
-	ARCHIVE DESTINATION ${SIDX_LIB_DIR})
+install(TARGETS spatialindex spatialindex_c
+        EXPORT libspatialindexTargets
+        RUNTIME DESTINATION ${SIDX_BIN_DIR}
+        LIBRARY DESTINATION ${SIDX_LIB_DIR}
+        ARCHIVE DESTINATION ${SIDX_LIB_DIR})
 
 export(
     TARGETS
-        ${SIDX_LIB_NAME} ${SIDX_C_LIB_NAME}
+        spatialindex spatialindex_c
     FILE
         "${SIDX_LIB_DIR}/libspatialindexTargets.cmake")
 
@@ -275,10 +265,10 @@ install(
     DESTINATION
         "${SIDX_LIB_DIR}/cmake/libspatialindex")
 
-target_include_directories(${SIDX_C_LIB_NAME}
+target_include_directories(spatialindex_c
     INTERFACE
         $<INSTALL_INTERFACE:include>)
-target_include_directories(${SIDX_LIB_NAME}
+target_include_directories(spatialindex
     INTERFACE
         $<INSTALL_INTERFACE:include>)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,17 +1,17 @@
 include_directories(../include)
 
-set (DIR geometry)
-set (SOURCES
+set(DIR geometry)
+set(SOURCES
         Intersection
         )
 
-foreach (test ${SOURCES})
+foreach(test ${SOURCES})
     add_executable(test-${DIR}-${test} ${DIR}/${test}.cc)
-    target_link_libraries(test-${DIR}-${test} ${SIDX_LIB_NAME})
+    target_link_libraries(test-${DIR}-${test} spatialindex)
 endforeach()
 
-set (DIR rtree)
-set (SOURCES
+set(DIR rtree)
+set(SOURCES
         Exhaustive
         Generator
         RTreeBulkLoad
@@ -19,13 +19,13 @@ set (SOURCES
         RTreeQuery)
 
 
-foreach (test ${SOURCES})
+foreach(test ${SOURCES})
     add_executable(test-${DIR}-${test} ${DIR}/${test}.cc)
-    target_link_libraries(test-${DIR}-${test} ${SIDX_LIB_NAME})
+    target_link_libraries(test-${DIR}-${test} spatialindex)
 endforeach()
 
-set (DIR mvrtree)
-set (SOURCES
+set(DIR mvrtree)
+set(SOURCES
         Exhaustive
         Generator
         MVRTreeLoad
@@ -33,13 +33,13 @@ set (SOURCES
         )
 
 
-foreach (test ${SOURCES})
+foreach(test ${SOURCES})
     add_executable(test-${DIR}-${test} ${DIR}/${test}.cc)
-    target_link_libraries(test-${DIR}-${test} ${SIDX_LIB_NAME})
+    target_link_libraries(test-${DIR}-${test} spatialindex)
 endforeach()
 
-set (DIR tprtree)
-set (SOURCES
+set(DIR tprtree)
+set(SOURCES
         Exhaustive
         Generator
         TPRTreeLoad
@@ -47,9 +47,10 @@ set (SOURCES
         )
 
 
-foreach (test ${SOURCES})
-    add_executable(test-${DIR}-${test} ${DIR}/${test}.cc ${DIR}/RandomGenerator.cc)
-    target_link_libraries(test-${DIR}-${test} ${SIDX_LIB_NAME})
+foreach(test ${SOURCES})
+    add_executable(test-${DIR}-${test}
+        ${DIR}/${test}.cc ${DIR}/RandomGenerator.cc)
+    target_link_libraries(test-${DIR}-${test} spatialindex)
 endforeach()
 
 add_subdirectory(gtest)

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -1,16 +1,18 @@
-set (GOOGLETEST_VERSION "1.10.0")
+set(GOOGLETEST_VERSION "1.10.0")
 
 add_subdirectory(gtest-1.10.0)
 include_directories(./gtest-1.10.0/include)
 
-set (SOURCES
+set(SOURCES
     test.h
     sidx_api_test.h
-    main.cc )
+    main.cc)
 
-set (TESTNAME libsidxtest)
+set(TESTNAME libsidxtest)
 add_executable(${TESTNAME} ${SOURCES})
-target_link_libraries(${TESTNAME} ${SIDX_C_LIB_NAME} gtest)
+target_link_libraries(${TESTNAME} spatialindex_c gtest)
 
-add_test(${TESTNAME} "${PROJECT_BINARY_DIR}/bin/${TESTNAME}" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/..")
+add_test(${TESTNAME}
+  "${PROJECT_BINARY_DIR}/bin/${TESTNAME}"
+  "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/..")
 


### PR DESCRIPTION
This PR does the minimal amount of changes from #191, including:

* Consistent formatting of CMakeLists.txt files using 'cmakelint'
* Use top project() to set VERSION and LANGUAGE to CXX
* Use CMAKE_CXX_STANDARD_REQUIRED=ON, CMAKE_CXX_EXTENSIONS=OFF
* SIDX_COMMON_CXX_FLAGS was previously ignored -- so use it for GNU and Clang
* Use CMake target names spatialindex and spatialindex_c rather than variables
* Disable unused <libname>_EXPORTS (based on DEFINE_SYMBOL)
* Remove set(CMAKE_COLOR_MAKEFILE ON)
* Remove unused APPS_CPP_DEPENDENCIES cached variable
* Remove old note about hack with add_definitions("-fPIC")
* CMAKE_MODULE_PATH was not used, remove logic