### PR TITLE
Intel compilers: resolve one warning, and enable default warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,19 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
     -Wredundant-decls
     -Wno-long-long
   )
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+  if(WIN32)
+    set(SIDX_COMMON_CXX_FLAGS
+      /Wall
+      /Qdiag-disable:2203  # cast discards qualifiers from target type
+    )
+  else()
+    set(SIDX_COMMON_CXX_FLAGS
+      -Wall
+      -Wpointer-arith
+      -diag-disable=2203  # cast discards qualifiers from target type
+    )
+  endif()
 endif()
 
 if(APPLE)

--- a/include/spatialindex/tools/Tools.h
+++ b/include/spatialindex/tools/Tools.h
@@ -320,7 +320,7 @@ namespace Tools
 // #else
 //             bool m_rwLock;
 // #endif
-		friend SIDX_DLL std::ostream& Tools::operator<<(std::ostream& os, const Tools::PropertySet& p);
+		friend SIDX_DLL std::ostream& operator<<(std::ostream& os, const Tools::PropertySet& p);
 	}; // PropertySet
 
 	// does not support degenerate intervals.


### PR DESCRIPTION
This PR primarily resolves one warning that repeats for each source file compilation:
```
[  1%] Building CXX object src/CMakeFiles/spatialindex.dir/capi/BoundsQuery.cc.o
In file included from /tmp/libspatialindex/src/../include/spatialindex/capi/../SpatialIndex.h(30),
                 from /tmp/libspatialindex/src/../include/spatialindex/capi/sidx_impl.h(36),
                 from /tmp/libspatialindex/src/capi/BoundsQuery.cc(29):
/tmp/libspatialindex/src/../include/spatialindex/capi/../tools/Tools.h(323): warning #1098: the qualifier on this friend declaration is ignored
  		friend SIDX_DLL std::ostream& Tools::operator<<(std::ostream& os, const Tools::PropertySet& p);
  		                              ^
```
---
A set of default warning flags are added for Intel compilers, with one diagnostic warning disabled. Project compiles cleanly with icpc (ICC) 19.1.0.166 20191121 on Linux, and tests pass. (Admittedly, I have not tested on Windows, but I don't see why this would behave differently.)