### PR TITLE
CMake: fix find_package(libspatialindex)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,26 +220,19 @@ if(BUILD_TESTING)
 endif()
 
 #------------------------------------------------------------------------------
-# CPack controls
+# CMake package configuration for find_package(libspatialindex)
 #------------------------------------------------------------------------------
-
 
 include(CMakePackageConfigHelpers)
 
-set(INCLUDE_INSTALL_DIR include/ CACHE PATH "include")
-set(LIB_INSTALL_DIR ${SIDX_LIB_DIR} CACHE PATH "lib")
-set(SYSCONFIG_INSTALL_DIR etc/pdal/ CACHE PATH "sysconfig")
-
-set(PDAL_CONFIG_INCLUDE_DIRS
-  "${CMAKE_INSTALL_PREFIX}/include")
-set(PDAL_CONFIG_LIBRARY_DIRS
-  "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}")
+set(INCLUDE_INSTALL_DIR ${SIDX_INCLUDE_DIR} CACHE PATH "include directory")
+set(LIB_INSTALL_DIR ${SIDX_LIB_DIR} CACHE PATH "lib directory")
 
 configure_package_config_file(
   libspatialindexConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/libspatialindexConfig.cmake
   INSTALL_DESTINATION ${LIB_INSTALL_DIR}/cmake/libspatialindex
-  PATH_VARS INCLUDE_INSTALL_DIR SYSCONFIG_INSTALL_DIR)
+  PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
 
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/libspatialindexConfigVersion.cmake
@@ -250,6 +243,10 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/libspatialindexConfig.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/libspatialindexConfigVersion.cmake
   DESTINATION ${LIB_INSTALL_DIR}/cmake/libspatialindex)
+
+#------------------------------------------------------------------------------
+# CPack controls
+#------------------------------------------------------------------------------
 
 set(CPACK_PACKAGE_VERSION_MAJOR ${SIDX_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${SIDX_VERSION_MINOR})

--- a/libspatialindexConfig.cmake.in
+++ b/libspatialindexConfig.cmake.in
@@ -9,6 +9,6 @@ set_and_check(SIDX_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 
 include("${CMAKE_CURRENT_LIST_DIR}/libspatialindexTargets.cmake")
 
-set(SIDX_LIBRARIES @SIDX_C_LIB_NAME@ @SIDX_LIB_NAME@)
+set(SIDX_LIBRARIES spatialindex_c spatialindex)
 
 check_required_components(libspatialindex)


### PR DESCRIPTION
It seems that a derivative CMake project that use `find_package(libspatialindex)` do not work as expected:
```
...
CMake Error at /tmp/lib/cmake/libspatialindex/libspatialindexConfig.cmake:11 (message):
  File or directory referenced by variable SIDX_LIB_DIR does not exist !

```
and sure enough, SIDX_LIB_DIR wasn't set to anything. This PR does several things:
* Add missing PATH_VARS: LIB_INSTALL_DIR
* Remove unused SYSCONFIG_INSTALL_DIR
* Remove other unused PDAL_* vars
* Change INCLUDE_INSTALL_DIR to SIDX_INCLUDE_DIR value
* SIDX_LIBRARIES must use constant library target names (this only matters to Windows builds)

These changes are not captured thru CI yet, however I have some postinstall tests that I'll see how to fit into the azp workflow.