### PR TITLE
CMake/azp: Test install and run post-install tests for demo apps

### DIFF
--- a/scripts/azp/linux.yml
+++ b/scripts/azp/linux.yml
@@ -9,17 +9,17 @@ jobs:
       matrix:
         GCC 8:
           CC: gcc-8
-          CXXSTD: 11, 14, 17, 20
+          CXXSTD: 11 14 17 20
           CXX: g++-8
           PACKAGES: g++-8
         GCC 7:
           CC: gcc-7
-          CXXSTD: 11, 14, 17
+          CXXSTD: 11 14 17
           CXX: g++-7
           PACKAGES: g++-7
         GCC 6:
           CC: gcc-6
-          CXXSTD: 11, 14
+          CXXSTD: 11 14
           CXX: g++-6
           PACKAGES: g++-6
         GCC 5:
@@ -39,43 +39,43 @@ jobs:
           PACKAGES: g++-4.8
         Clang 8:
           CC: clang-8
-          CXXSTD: 11, 14, 17, 20
+          CXXSTD: 11 14 17 20
           CXX: clang++-8
           PACKAGES: clang-8
           LLVM_REPO: llvm-toolchain-xenial-8
         Clang 7:
           CC: clang-7
-          CXXSTD: 14, 17, 20
+          CXXSTD: 14 17 20
           CXX: clang++-7
           PACKAGES: clang-7
           LLVM_REPO: llvm-toolchain-xenial-7
         Clang 6:
           CC: clang-6.0
-          CXXSTD: 14, 17, 20
+          CXXSTD: 14 17 20
           CXX: clang++-6.0
           PACKAGES: clang-6.0
           LLVM_REPO: llvm-toolchain-xenial-6.0
         Clang 5:
           CC: clang-5.0
-          CXXSTD: 11, 14, 17
+          CXXSTD: 11 14 17
           PACKAGES: clang-5.0
           CXX: clang++-5.0
           LLVM_REPO: llvm-toolchain-xenial-5.0
         Clang 4:
           CC: clang-4.0
-          CXXSTD: 11, 14
+          CXXSTD: 11 14
           CXX: clang++-4.0
           PACKAGES: clang-4.0
           LLVM_REPO: llvm-toolchain-xenial-4.0
         Clang 3.9:
           CC: clang-3.9
-          CXXSTD: 11, 14
+          CXXSTD: 11 14
           CXX: clang++-3.9
           PACKAGES: clang-3.9
         Clang 3.8:
           CC: clang-3.8
           CXX: clang++-3.8
-          CXXSTD: 11, 14
+          CXXSTD: 11 14
           PACKAGES: clang-3.8
     steps:
     - script: |
@@ -88,48 +88,65 @@ jobs:
         fi
         sudo -E apt-get update
         sudo -E apt-get -yq --no-install-suggests --no-install-recommends install cmake ${PACKAGES}
-      displayName: 'Install'
+      displayName: 'Install dependencies'
     - script: |
         set -e
         mkdir build.cxx11
         cd build.cxx11
-        cmake --version
-        cmake -DCMAKE_CXX_STANDARD=11 -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        prefix=/tmp/cxx11
+        cmake -DCMAKE_CXX_STANDARD=11 -DCMAKE_INSTALL_PREFIX=$prefix -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
         VERBOSE=1 make
-        pushd ..
+        ctest -V --output-on-failure
+        make install
+        cd ..
         export PATH=$PATH:`pwd`/build.cxx11/bin
         ./scripts/azp/linux-test.sh
-        popd
+        ./test/postinstall/test_cmake.sh $prefix 11
       displayName: 'Build C++11'
       condition: contains(variables['CXXSTD'], '11')
     - script: |
         set -e
         mkdir build.cxx14
         cd build.cxx14
-        cmake --version
-        cmake -DCMAKE_CXX_STANDARD=14 -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        prefix=/tmp/cxx14
+        cmake -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX=$prefix -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
         VERBOSE=1 make
         ctest -V --output-on-failure
+        make install
+        cd ..
+        export PATH=$PATH:`pwd`/build.cxx11/bin
+        ./scripts/azp/linux-test.sh
+        ./test/postinstall/test_cmake.sh $prefix 14
       displayName: 'Build C++14'
       condition: contains(variables['CXXSTD'], '14')
     - script: |
         set -e
         mkdir build.cxx17
         cd build.cxx17
-        cmake --version
-        cmake -DCMAKE_CXX_STANDARD=17 -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        prefix=/tmp/cxx17
+        cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$prefix -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
         VERBOSE=1 make
         ctest -V --output-on-failure
+        make install
+        cd ..
+        export PATH=$PATH:`pwd`/build.cxx11/bin
+        ./scripts/azp/linux-test.sh
+        ./test/postinstall/test_cmake.sh $prefix 17
       displayName: 'Build C++17'
       condition: contains(variables['CXXSTD'], '17')
     - script: |
         set -e
         mkdir build.cxx20
         cd build.cxx20
-        cmake --version
-        cmake -DCMAKE_CXX_STANDARD=20 -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        prefix=/tmp/cxx20
+        cmake -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=$prefix -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
         VERBOSE=1 make
         ctest -V --output-on-failure
+        make install
+        cd ..
+        export PATH=$PATH:`pwd`/build.cxx11/bin
+        ./scripts/azp/linux-test.sh
+        ./test/postinstall/test_cmake.sh $prefix 20
       displayName: 'Build C++20'
       condition: contains(variables['CXXSTD'], '20')
 

--- a/scripts/azp/osx.yml
+++ b/scripts/azp/osx.yml
@@ -9,7 +9,7 @@ jobs:
   - script: |
       mkdir build
       cd build
-      cmake -DBUILD_TESTING=ON ..
+      cmake -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=/tmp/sidx ..
     displayName: 'CMake'
   - script: |
       cd build
@@ -22,4 +22,8 @@ jobs:
   - script: |
       cd build
       make dist
-    displayName: 'Dist'
+      make install
+    displayName: 'Dist and install'
+  - script: |
+      ./test/postinstall/test_cmake.sh /tmp/sidx
+    displayName: 'Post-install test'

--- a/scripts/azp/win.yml
+++ b/scripts/azp/win.yml
@@ -35,6 +35,7 @@ jobs:
             -DCMAKE_INCLUDE_PATH:FILEPATH="%CONDA_PREFIX%/Library/include" ^
             -DBUILD_SHARED_LIBS=ON ^
             -DBUILD_TESTING=ON ^
+            -DCMAKE_INSTALL_PREFIX="%TEMP%\sidx" ^
             -Dgtest_force_shared_crt=ON ^
         ..
       displayName: 'CMake'
@@ -64,4 +65,11 @@ jobs:
         pushd build
         call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
         ninja dist
-      displayName: 'dist'
+        ninja install
+      displayName: 'Dist and install'
+    - script: |
+        ECHO ON
+        call activate libspatialindex
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+        call test\postinstall\test_cmake.bat %TEMP%\sidx
+      displayName: 'Post-install test'

--- a/test/postinstall/test_c/CMakeLists.txt
+++ b/test/postinstall/test_c/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.5)
+project(test_c LANGUAGES C)
+
+
+find_package(libspatialindex)
+
+# Show some target properties
+get_cmake_property(_variableNames VARIABLES)
+list(SORT _variableNames)
+foreach(_variableName ${_variableNames})
+  string(REGEX MATCH "^SIDX_" _matched ${_variableName})
+  if(NOT ${_matched} STREQUAL "")
+    message(STATUS "${_variableName}=${${_variableName}}")
+  endif()
+endforeach()
+
+add_executable(test_c test_c.c)
+target_link_libraries(test_c ${SIDX_LIBRARIES})
+
+include(CTest)
+
+if(APPLE)
+  set(LDD_CL "otool -L")
+  # set(EXPECTED_LDD_CL_OUT "@rpath/libspatialindex")
+  set(EXPECTED_LDD_CL_OUT "${CMAKE_PREFIX_PATH}/lib/libspatialindex")
+elseif(UNIX)
+  set(LDD_CL "ldd")
+  set(EXPECTED_LDD_CL_OUT "${CMAKE_PREFIX_PATH}/lib/libspatialindex")
+endif()
+
+if(LDD_CL)
+  add_test(NAME test_ldd
+    COMMAND sh -c "${LDD_CL} ${CMAKE_BINARY_DIR}/test_c | grep libspatialindex")
+  set_tests_properties(test_ldd PROPERTIES
+    PASS_REGULAR_EXPRESSION ${EXPECTED_LDD_CL_OUT}
+  )
+else()
+  # Dummy test
+  add_test(NAME test_ldd COMMAND test_c)
+  set_tests_properties(test_ldd PROPERTIES SKIP_RETURN_CODE 0)
+endif()
+
+add_test(NAME test_version COMMAND test_c)
+set(SIDX_VERSION_STRING
+  "${SIDX_VERSION_MAJOR}.${SIDX_VERSION_MINOR}.${SIDX_VERSION_PATCH}")
+set_tests_properties(test_version PROPERTIES
+  PASS_REGULAR_EXPRESSION ${SIDX_VERSION_STRING}
+)

--- a/test/postinstall/test_c/test_c.c
+++ b/test/postinstall/test_c/test_c.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <spatialindex/capi/sidx_api.h>
+
+int main(int argc, char *argv[]) {
+    char* pszVersion = SIDX_Version();
+    printf("%s\n", pszVersion);
+    return(0);
+}

--- a/test/postinstall/test_cc/CMakeLists.txt
+++ b/test/postinstall/test_cc/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.5)
+project(test_cc LANGUAGES CXX)
+message(STATUS "CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
+
+find_package(libspatialindex)
+
+# Show some target properties
+get_cmake_property(_variableNames VARIABLES)
+list(SORT _variableNames)
+foreach(_variableName ${_variableNames})
+  string(REGEX MATCH "^SIDX_" _matched ${_variableName})
+  if(NOT ${_matched} STREQUAL "")
+    message(STATUS "${_variableName}=${${_variableName}}")
+  endif()
+endforeach()
+
+add_executable(test_cc test_cc.cc)
+target_link_libraries(test_cc ${SIDX_LIBRARIES})
+
+include(CTest)
+
+if(APPLE)
+  set(LDD_CL "otool -L")
+  # set(EXPECTED_LDD_CL_OUT "@rpath/libspatialindex")
+  set(EXPECTED_LDD_CL_OUT "${CMAKE_PREFIX_PATH}/lib/libspatialindex")
+elseif(UNIX)
+  set(LDD_CL "ldd")
+  set(EXPECTED_LDD_CL_OUT "${CMAKE_PREFIX_PATH}/lib/libspatialindex")
+endif()
+
+if(LDD_CL)
+  add_test(NAME test_ldd
+    COMMAND sh -c "${LDD_CL} ${CMAKE_BINARY_DIR}/test_cc | grep libspatialindex")
+  set_tests_properties(test_ldd PROPERTIES
+    PASS_REGULAR_EXPRESSION ${EXPECTED_LDD_CL_OUT}
+  )
+else()
+  # Dummy test
+  add_test(NAME test_ldd COMMAND test_cc)
+  set_tests_properties(test_ldd PROPERTIES SKIP_RETURN_CODE 0)
+endif()
+
+add_test(NAME test_cout COMMAND test_cc)
+set_tests_properties(test_cout PROPERTIES
+  PASS_REGULAR_EXPRESSION "done"
+)

--- a/test/postinstall/test_cc/test_cc.cc
+++ b/test/postinstall/test_cc/test_cc.cc
@@ -1,0 +1,11 @@
+#include <iostream>
+#include <spatialindex/SpatialIndex.h>
+
+using namespace SpatialIndex;
+
+int main(int argc, char** argv) {
+    double c1[2] = {1.0, 0.0};
+    Point p1 = Point(&c1[0], 2);
+    std::cout << "done" << std::endl;
+    return(0);
+}

--- a/test/postinstall/test_cmake.bat
+++ b/test/postinstall/test_cmake.bat
@@ -1,0 +1,62 @@
+@echo off
+
+:: Post-install tests with CMake
+::
+:: First required argument is the installed prefix, which
+:: is used to set CMAKE_PREFIX_PATH and PATH
+::
+:: Second optional argument is CXXSTD, with default 11
+
+
+echo Running post-install tests with CMake
+
+set prefix=%1
+if not defined prefix (
+    echo First positional argument to the installed prefix is required
+    exit /B 1
+)
+
+set PATH=%PATH%;%prefix%\bin
+
+set CXXSTD=%2
+if not defined CXXSTD (
+    set CXXSTD=11
+)
+
+
+set CC=cl.exe
+
+set CXX=cl.exe
+
+echo %PATH%
+
+dir %prefix%\bin
+
+
+
+cd %~dp0
+
+cd test_c
+del /f /q build 2> nul
+md build
+cd build
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%prefix% .. || exit /B 2
+ninja -v || exit /B 3
+dumpbin /DEPENDENTS test_c.exe
+ctest -V --output-on-failure || exit /B 4
+cd ..
+del /f /q build
+cd ..
+
+cd test_cc
+del /f /q build 2> nul
+md build
+cd build
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%prefix% -DCMAKE_CXX_STANDARD=%CXXSTD% .. || exit /B 2
+ninja -v || exit /B 3
+dumpbin /DEPENDENTS test_cc.exe
+ctest -V --output-on-failures || exit /B 4
+cd ..
+del /f /q build
+cd ..
+

--- a/test/postinstall/test_cmake.sh
+++ b/test/postinstall/test_cmake.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+#  Post-install tests with CMake
+#
+#  First required argument is the installed prefix, which
+#  is used to set CMAKE_PREFIX_PATH and LD_LIBRARY_PATH
+#
+#  Second optional argument is CXXSTD, with default 11
+
+set -e
+echo Running post-install tests with CMake
+
+prefix=$1
+if [ -z "$prefix" ]; then
+    echo First positional argument to the installed prefix is required
+    exit 1
+fi
+
+export LD_LIBRARY_PATH=$prefix/lib
+
+CXXSTD=$2
+if [ -z "$CXXSTD" ]; then
+    CXXSTD=11
+fi
+
+UNAME=$(uname)
+case $UNAME in
+  Darwin*)
+    alias ldd="otool -L" ;;
+  Linux*)
+    ;;
+  *)
+    echo "no ldd equivalent found for UNAME=$UNAME"
+    exit 1 ;;
+esac
+
+cd $(dirname $0)
+
+cd test_c
+rm -rf build
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$prefix ..
+VERBOSE=1 make
+ldd ./test_c
+ctest -V --output-on-failure
+cd ..
+rm -rf build
+cd ..
+
+cd test_cc
+rm -rf build
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$prefix -DCMAKE_CXX_STANDARD=$CXXSTD ..
+VERBOSE=1 make
+ldd ./test_cc
+ctest -V --output-on-failure
+cd ..
+rm -rf build
+cd ..
+


### PR DESCRIPTION
There's a few things going on here:
* Install of libspatilindex is done (rather than just building/testing)
* CMake's `find_package(libspatialindex)` is tested to build and C and C++ applications, using dynamic linking
* The installed C API is tested to build C programs (it appears this has been broken in the past)

For the Linux build, this is only tested along side the C++11 build. For OSX and Windows, "Dist" now does "Dist and install", followed by "Post-install test".

The test C and C++ apps do trivial things with libspatialindex, and essentially make sure the application linking is done as expected. There is no author/copyright info in these source files, since they are trivial. However, if this consistency is preferred, I can add it to the source files. (And yes, I'm the original author of these.)