### PR TITLE
pkg-config: restore functionality (via CMake), change Cflags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ docs/build
 install_manifest.txt
 docs/doxygen/html/
 docs/doxygen/xml
-src/libspatialindex.pc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,20 @@ install(FILES
   DESTINATION ${LIB_INSTALL_DIR}/cmake/libspatialindex)
 
 #------------------------------------------------------------------------------
+# pkg-config support
+#------------------------------------------------------------------------------
+if(NOT WIN32)
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/libspatialindex.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/libspatialindex.pc
+    @ONLY)
+
+  install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/libspatialindex.pc
+    DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+endif()
+
+#------------------------------------------------------------------------------
 # CPack controls
 #------------------------------------------------------------------------------
 

--- a/src/libspatialindex.pc.in
+++ b/src/libspatialindex.pc.in
@@ -1,12 +1,12 @@
-prefix=@prefix@
-exec_prefix=@exec_prefix@
-libdir=@libdir@
-includedir=@includedir@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@LIB_INSTALL_DIR@
+includedir=${prefix}/@INCLUDE_INSTALL_DIR@
 
 Name: libspatialindex 
 Description: Generic C/C++ library for spatial indexing
 Requires: 
-Version: @PACKAGE_VERSION@
-Libs: -L@libdir@ -lspatialindex
-Cflags: -I${includedir}/spatialindex
+Version: @SIDX_VERSION_STRING@
+Libs: -L${libdir} -lspatialindex
+Cflags: -I${includedir}
 


### PR DESCRIPTION
The [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) was lost when the autotools setup was removed, however some users may want to use this interface. It's simple to install from the CMake setup.

One of the issues with the previous pkg-config file is that it had:
```
Cflags: -I${includedir}/spatialindex
```
which is impossible to use with a C header `#include <spatialindex/capi/sidx_api.h>`. It is changed/fixed in this PR.

Some post-install tests (similar to #200) will be added when ready.