### PR TITLE
azp: Run post-install tests for demo apps with pkg-config

### DIFF
--- a/scripts/azp/linux.yml
+++ b/scripts/azp/linux.yml
@@ -102,6 +102,7 @@ jobs:
         export PATH=$PATH:`pwd`/build.cxx11/bin
         ./scripts/azp/linux-test.sh
         ./test/postinstall/test_cmake.sh $prefix 11
+        ./test/postinstall/test_pkg-config.sh $prefix
       displayName: 'Build C++11'
       condition: contains(variables['CXXSTD'], '11')
     - script: |
@@ -117,6 +118,7 @@ jobs:
         export PATH=$PATH:`pwd`/build.cxx11/bin
         ./scripts/azp/linux-test.sh
         ./test/postinstall/test_cmake.sh $prefix 14
+        ./test/postinstall/test_pkg-config.sh $prefix
       displayName: 'Build C++14'
       condition: contains(variables['CXXSTD'], '14')
     - script: |
@@ -132,6 +134,7 @@ jobs:
         export PATH=$PATH:`pwd`/build.cxx11/bin
         ./scripts/azp/linux-test.sh
         ./test/postinstall/test_cmake.sh $prefix 17
+        ./test/postinstall/test_pkg-config.sh $prefix
       displayName: 'Build C++17'
       condition: contains(variables['CXXSTD'], '17')
     - script: |
@@ -147,6 +150,7 @@ jobs:
         export PATH=$PATH:`pwd`/build.cxx11/bin
         ./scripts/azp/linux-test.sh
         ./test/postinstall/test_cmake.sh $prefix 20
+        ./test/postinstall/test_pkg-config.sh $prefix
       displayName: 'Build C++20'
       condition: contains(variables['CXXSTD'], '20')
 

--- a/scripts/azp/osx.yml
+++ b/scripts/azp/osx.yml
@@ -7,6 +7,9 @@ jobs:
   timeoutInMinutes: 360
   steps:
   - script: |
+      brew install pkg-config
+    displayName: 'Install dependencies'
+  - script: |
       mkdir build
       cd build
       cmake -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=/tmp/sidx ..
@@ -26,4 +29,5 @@ jobs:
     displayName: 'Dist and install'
   - script: |
       ./test/postinstall/test_cmake.sh /tmp/sidx
+      ./test/postinstall/test_pkg-config.sh /tmp/sidx
     displayName: 'Post-install test'

--- a/test/postinstall/test_c/Makefile
+++ b/test/postinstall/test_c/Makefile
@@ -1,0 +1,15 @@
+PROGRAM = test_c
+OBJECTS = test_c.o
+
+override CFLAGS += -g -Wall -Werror $(shell pkg-config libspatialindex --cflags)
+override LDFLAGS += $(shell pkg-config libspatialindex --libs)
+
+all: $(PROGRAM)
+
+$(PROGRAM): $(OBJECTS)
+	$(CC) -o $@ $< $(LDFLAGS)
+
+clean:
+	$(RM) $(PROGRAM) $(OBJECTS)
+
+.PHONY: clean

--- a/test/postinstall/test_cc/Makefile
+++ b/test/postinstall/test_cc/Makefile
@@ -1,0 +1,15 @@
+PROGRAM = test_cc
+OBJECTS = test_cc.o
+
+override CXXFLAGS += -std=c++11 -g -Wall -Werror $(shell pkg-config libspatialindex --cflags)
+override LDFLAGS += $(shell pkg-config libspatialindex --libs)
+
+all: $(PROGRAM)
+
+$(PROGRAM): $(OBJECTS)
+	$(CXX) -o $@ $< $(LDFLAGS)
+
+clean:
+	$(RM) $(PROGRAM) $(OBJECTS)
+
+.PHONY: clean

--- a/test/postinstall/test_pkg-config.sh
+++ b/test/postinstall/test_pkg-config.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+#  Post-install tests with pkg-config
+#
+#  First required argument is the installed prefix, which
+#  is used to set PKG_CONFIG_PATH and LD_LIBRARY_PATH
+
+echo Running post-install tests with pkg-config
+
+prefix=$1
+if [ -z "$prefix" ]; then
+    echo First positional argument to the the installed prefix is required
+    exit 1
+fi
+
+export PKG_CONFIG_PATH=$prefix/lib/pkgconfig
+export LD_LIBRARY_PATH=$prefix/lib
+
+# Run tests from shell, count any errors
+ERRORS=0
+NTESTS=0
+
+UNAME=$(uname)
+case $UNAME in
+  Darwin*)
+    alias ldd="otool -L" ;;
+  Linux*)
+    ;;
+  *)
+    echo "no ldd equivalent found for UNAME=$UNAME"
+    exit 1 ;;
+esac
+
+check_ldd(){
+  NTESTS=$(($NTESTS + 1))
+  printf "Testing expected ldd output ... "
+  LDD_OUTPUT=$(ldd ./$1 | grep libspatialindex)
+  LDD_SUBSTR=$LD_LIBRARY_PATH/libspatialindex.
+  case "$LDD_OUTPUT" in
+    *$LDD_SUBSTR*)
+      echo "passed" ;;
+    *)
+      ERRORS=$(($ERRORS + 1))
+      echo "failed: ldd output '$LDD_OUTPUT' does not contain '$LDD_SUBSTR'" ;;
+  esac
+}
+
+cd $(dirname $0)
+
+
+cd test_c
+make clean
+make
+
+check_ldd test_c
+
+printf "Testing expected version ... "
+NTESTS=$(($NTESTS + 1))
+VERSION_OUTPUT=$(./test_c)
+PKG_CONFIG_MODVERSION=$(pkg-config libspatialindex --modversion)
+case "$VERSION_OUTPUT" in
+  $PKG_CONFIG_MODVERSION)
+    echo "passed" ;;
+  *)
+    ERRORS=$(($ERRORS + 1))
+    echo "failed: '$VERSION_OUTPUT' != '$PKG_CONFIG_MODVERSION'" ;;
+esac
+
+make clean
+cd ..
+
+
+cd test_cc
+make clean
+make
+
+check_ldd test_cc
+
+printf "Testing expected outputs ... "
+NTESTS=$(($NTESTS + 1))
+OUTPUT=$(./test_cc)
+case "$OUTPUT" in
+  "done")
+    echo "passed" ;;
+  *)
+    ERRORS=$(($ERRORS + 1))
+    echo "failed: '$OUTPUT' != 'done'" ;;
+esac
+
+make clean
+cd ..
+
+echo "$ERRORS tests failed out of $NTESTS"
+exit $ERRORS


### PR DESCRIPTION
This PR adds to post-install tests for demo apps (#200) by testing installed pkg-config files (#201).