### PR TITLE
azp: fix linux test PATH, always use 'set -e' for osx

### DIFF
--- a/scripts/azp/linux.yml
+++ b/scripts/azp/linux.yml
@@ -115,7 +115,7 @@ jobs:
         ctest -V --output-on-failure
         make install
         cd ..
-        export PATH=$PATH:`pwd`/build.cxx11/bin
+        export PATH=$PATH:`pwd`/build.cxx14/bin
         ./scripts/azp/linux-test.sh
         ./test/postinstall/test_cmake.sh $prefix 14
         ./test/postinstall/test_pkg-config.sh $prefix
@@ -131,7 +131,7 @@ jobs:
         ctest -V --output-on-failure
         make install
         cd ..
-        export PATH=$PATH:`pwd`/build.cxx11/bin
+        export PATH=$PATH:`pwd`/build.cxx17/bin
         ./scripts/azp/linux-test.sh
         ./test/postinstall/test_cmake.sh $prefix 17
         ./test/postinstall/test_pkg-config.sh $prefix
@@ -147,7 +147,7 @@ jobs:
         ctest -V --output-on-failure
         make install
         cd ..
-        export PATH=$PATH:`pwd`/build.cxx11/bin
+        export PATH=$PATH:`pwd`/build.cxx20/bin
         ./scripts/azp/linux-test.sh
         ./test/postinstall/test_cmake.sh $prefix 20
         ./test/postinstall/test_pkg-config.sh $prefix

--- a/scripts/azp/osx.yml
+++ b/scripts/azp/osx.yml
@@ -23,11 +23,13 @@ jobs:
       ctest -V --output-on-failure
     displayName: 'Test'
   - script: |
+      set -e
       cd build
       make dist
       make install
     displayName: 'Dist and install'
   - script: |
+      set -e
       ./test/postinstall/test_cmake.sh /tmp/sidx
       ./test/postinstall/test_pkg-config.sh /tmp/sidx
     displayName: 'Post-install test'


### PR DESCRIPTION
Just realised that YAML lists are `key: [0, 1]`, and not `key: 0, 1` or `key: 0 1`. (Update: they shouldn't be lists)

osx was missing some `set -e` options to catch potential errors.

<s>Checking to see if repetition for build step can be compacted.</s>

Fix linux test PATH for build dirnames.