### PR TITLE
Update README.rst Revision and Date to match other docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
 
 :Author: Marios Hadjieleftheriou
 :Contact: mhadji@gmail.com
-:Revision: 1.9.1
-:Date: 10/19/2019
+:Revision: 1.9.3
+:Date: 10/23/2019
 
 See http://libspatialindex.org for full documentation.


### PR DESCRIPTION
This is a small change to just the main README.rst. Our sysadmins want the docs to match the release number before installing this library.