### PR TITLE
Added Ball Shape for point neighborhood queries

### DIFF
--- a/include/spatialindex/Ball.h
+++ b/include/spatialindex/Ball.h
@@ -1,0 +1,98 @@
+/******************************************************************************
+ * Project:  libspatialindex - A C++ library for spatial indexing
+ * Author:   Peter Labadorf - plaba3.1415@gmail.com
+ ******************************************************************************
+ * Copyright (c) 2023, Peter Labadorf
+ *
+ * All rights reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+******************************************************************************/
+
+#pragma once
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace SpatialIndex
+{
+
+	class SIDX_DLL Ball: public Tools::IObject, public virtual IShape
+	{
+	public:
+		Ball();
+		Ball(double radius, const Point& center);
+		Ball(double radius, const double *pCoords, uint32_t dimension);
+		Ball(const Ball& b);
+		~Ball() override;
+
+		virtual Ball& operator=(const Ball& b);
+		virtual bool operator==(const Ball& b) const;
+
+		//
+		// IObject interface
+		//
+
+		Ball* clone() override;
+
+		//
+		// ISerializable interface
+		//
+
+		uint32_t getByteArraySize() override;
+		void loadFromByteArray(const uint8_t *data) override;
+		void storeToByteArray(uint8_t **data, uint32_t &length) override;
+
+		//
+		// IShape interface
+		//
+
+		bool intersectsShape(const IShape &in) const override;
+		bool containsShape(const IShape &in) const override;
+		bool touchesShape(const IShape &in) const override;
+		void getCenter(SpatialIndex::Point &out) const override;
+		uint32_t getDimension() const override;
+		void getMBR(SpatialIndex::Region &out) const override;
+		double getArea() const override;
+		double getMinimumDistance(const IShape &in) const override;
+
+		virtual bool containsLineSegment(const SpatialIndex::LineSegment *line) const;
+		virtual bool containsRegion(const SpatialIndex::Region *region) const;
+
+		inline bool containsPoint(const Point *point) const
+		{
+			return getMinimumDistance(*point) <= m_centerPoint.m_dimension;
+		}
+
+		inline bool containsBall(const Ball *ball) const
+		{
+			return getMinimumDistance(ball->m_centerPoint) + ball->m_radius <= m_radius;
+		}
+
+	public:
+		double m_radius{0.0};
+		Point m_centerPoint;
+
+	}; // Ball
+
+	SIDX_DLL std::ostream& operator<<(std::ostream& os, const Ball& ball);
+
+}
+

--- a/include/spatialindex/SpatialIndex.h
+++ b/include/spatialindex/SpatialIndex.h
@@ -36,6 +36,7 @@
 namespace SpatialIndex
 {
 	class Point;
+	class Ball;
 	class LineSegment;
 	class Region;
 
@@ -246,6 +247,7 @@ namespace SpatialIndex
 
 #include "Point.h"
 #include "Region.h"
+#include "Ball.h"
 #include "LineSegment.h"
 #include "TimePoint.h"
 #include "TimeRegion.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SIDX_CAPI_DIR "${PROJECT_SOURCE_DIR}/src/capi")
 # base
 #
 set(SIDX_BASE_HPP
+  "${SIDX_HEADERS_DIR}/Ball.h"
   "${SIDX_HEADERS_DIR}/LineSegment.h"
   "${SIDX_HEADERS_DIR}/MovingPoint.h"
   "${SIDX_HEADERS_DIR}/MVRTree.h"
@@ -74,6 +75,7 @@ set(SIDX_CAPI_CPP
 list(APPEND SIDX_CPP ${SIDX_CAPI_CPP})
 
 set(SIDX_SPATIALINDEX_CPP
+  "${SIDX_SRC_DIR}/spatialindex/Ball.cc"
   "${SIDX_SRC_DIR}/spatialindex/LineSegment.cc"
   "${SIDX_SRC_DIR}/spatialindex/MovingPoint.cc"
   "${SIDX_SRC_DIR}/spatialindex/MovingRegion.cc"

--- a/src/spatialindex/Ball.cc
+++ b/src/spatialindex/Ball.cc
@@ -1,0 +1,219 @@
+/******************************************************************************
+ * Project:  libspatialindex - A C++ library for spatial indexing
+ * Author:   Peter Labadorf - plaba3.1415@gmail.com
+ ******************************************************************************
+ * Copyright (c) 2023, Peter Labadorf
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+******************************************************************************/
+
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+#include <spatialindex/SpatialIndex.h>
+
+using namespace SpatialIndex;
+
+Ball::Ball()
+= default;
+
+Ball::Ball(const Ball &b)
+{
+	m_centerPoint = b.m_centerPoint;
+	m_radius = b.m_radius;
+}
+
+Ball::Ball(double radius, const Point &center)
+{
+	m_centerPoint = center;
+	m_radius = radius;
+}
+
+Ball::Ball(double radius, const double *pCoords, uint32_t dimension)
+{
+	m_centerPoint = Point(pCoords, dimension);
+	m_radius = radius;
+}
+
+Ball::~Ball()
+= default;
+
+Ball &Ball::operator=(const Ball &b)
+{
+	if(this != &b)
+	{
+		m_radius = b.m_radius;
+		m_centerPoint = b.m_centerPoint;
+	}
+	return *this;
+}
+
+bool Ball::operator==(const Ball &b) const
+{
+	return fabs(m_radius - b.m_radius) <= std::numeric_limits<double>::epsilon()
+		&& m_centerPoint == b.m_centerPoint;
+}
+
+//
+// IObject interface
+//
+Ball *Ball::clone()
+{
+	return new Ball(*this);
+}
+
+//
+// ISerializable interface
+//
+uint32_t Ball::getByteArraySize()
+{
+	return m_centerPoint.getByteArraySize() + sizeof(double);
+}
+
+void Ball::loadFromByteArray(const uint8_t *data)
+{
+	m_centerPoint.loadFromByteArray(data);
+	data += m_centerPoint.getByteArraySize();
+	memcpy(&m_radius, data, sizeof(double));
+}
+
+void Ball::storeToByteArray(uint8_t **data, uint32_t &length)
+{
+	uint32_t center_point_size;
+	length = getByteArraySize();
+
+	*data = new uint8_t[length];
+	uint8_t *ptr = *data;
+
+	m_centerPoint.storeToByteArray(&ptr, center_point_size);
+
+	ptr += center_point_size;
+	memcpy(ptr, &m_radius, sizeof(double));
+}
+
+//
+// IShape interface
+//
+bool Ball::intersectsShape(const IShape &in) const
+{
+	return in.getMinimumDistance(m_centerPoint) <= m_radius;
+}
+
+bool Ball::containsShape(const IShape &in) const
+{
+	if (in.getDimension() != m_centerPoint.m_dimension)
+		throw Tools::IllegalArgumentException(
+			"Ball::containsShape: Shape has the wrong number of dimensions."
+		);
+
+	const Point *point = dynamic_cast<const Point*>(&in);
+	if (point != nullptr) return containsPoint(point);
+
+	const LineSegment *line = dynamic_cast<const LineSegment*>(&in);
+	if (line != nullptr) return containsLineSegment(line);
+
+	const Region *region = dynamic_cast<const Region*>(&in);
+	if (region != nullptr) return containsRegion(region);
+
+	const Ball *ball = dynamic_cast<const Ball*>(&in);
+	if (ball != nullptr) return containsBall(ball);
+
+	throw Tools::IllegalStateException(
+		"Ball::intersectsShape: Not implemented yet!"
+	);
+}
+
+bool Ball::touchesShape(const IShape &in) const
+{
+	return fabs(in.getMinimumDistance(m_centerPoint) - m_radius) <=
+		std::numeric_limits<double>::epsilon();
+}
+
+void Ball::getCenter(Point &out) const
+{
+	out = m_centerPoint;
+}
+
+uint32_t Ball::getDimension() const
+{
+	return m_centerPoint.m_dimension;
+}
+
+void Ball::getMBR(Region &out) const
+{
+	out = Region(m_centerPoint, m_centerPoint);
+	for (uint16_t i = 0; i < m_centerPoint.m_dimension; i++)
+	{
+		out.m_pLow[i] -= m_radius;
+		out.m_pHigh[i] += m_radius;
+	}
+}
+
+double Ball::getArea() const
+{
+	return std::pow(m_radius, m_centerPoint.m_dimension) *
+		std::pow(M_PI, m_centerPoint.m_dimension / 2) /
+		std::tgamma(m_centerPoint.m_dimension / 2 + 1);
+}
+
+double Ball::getMinimumDistance(const IShape &in) const
+{
+	return std::max(in.getMinimumDistance(m_centerPoint) - m_radius, 0.0);
+}
+
+bool Ball::containsRegion(const Region *region) const
+{
+	double sum = 0;
+	for (uint32_t i = 0; i < m_centerPoint.m_dimension; i++)
+	{
+		double furthest = std::max(std::abs(m_centerPoint.m_pCoords[i] - region->m_pLow[i]),
+			std::abs(region->m_pHigh[i] - m_centerPoint.m_pCoords[i]));
+		sum += furthest * furthest;
+	}
+	return sum <= m_radius * m_radius;
+}
+
+bool Ball::containsLineSegment(const LineSegment *line) const
+{
+	double sum = 0;
+	for (uint32_t i = 0; i < m_centerPoint.m_dimension; i++)
+	{
+		double d = line->m_pStartPoint[i] - m_centerPoint.m_pCoords[i];
+		sum += d * d;
+	}
+	if (sum > m_radius * m_radius) return false;
+
+	sum = 0;
+	for (uint32_t i = 0; i < m_centerPoint.m_dimension; i++)
+	{
+		double d = line->m_pEndPoint[i] - m_centerPoint.m_pCoords[i];
+		sum += d * d;
+	}
+
+	return sum <= m_radius * m_radius;
+}
+
+std::ostream &SpatialIndex::operator<<(std::ostream &os, const Ball &ball)
+{
+	os << ball.m_centerPoint << " " << ball.m_radius << " ";
+	return os;
+}

--- a/test/gtest/gtest-1.10.0/src/gtest-death-test.cc
+++ b/test/gtest/gtest-1.10.0/src/gtest-death-test.cc
@@ -1296,8 +1296,8 @@ static void StackLowerThanAddress(const void* ptr, bool* result) {
 GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
 GTEST_ATTRIBUTE_NO_SANITIZE_HWADDRESS_
 static bool StackGrowsDown() {
-  int dummy;
-  bool result;
+  int dummy = 0;
+  bool result = false;
   StackLowerThanAddress(&dummy, &result);
   return result;
 }


### PR DESCRIPTION
Hello!

I've written a Ball Shape that can be used in intersection and containsWhat queries to find all objects in the tree within a certain distance of a point.

A function in [test/gtest/gtest-1.10.0/src/gtest-death-test.cc](https://github.com/libspatialindex/libspatialindex/compare/master...Plaba:libspatialindex:master?expand=1#diff-75b9ab41264f983c418b1bc3eb3ad15a436e7a3a168838b88aca7a2f88c89177) was raising -Werror=maybe-uninitialized on compilation and breaking builds, so I fixed that as well. 