### PR TITLE
Fix #236 - Open read-only and don't flush if index exists and overwrite is false

### DIFF
--- a/src/storagemanager/DiskStorageManager.cc
+++ b/src/storagemanager/DiskStorageManager.cc
@@ -168,14 +168,16 @@ DiskStorageManager::DiskStorageManager(Tools::PropertySet& ps) : m_pageSize(0), 
 		bFileExists = CheckFilesExists(ps);
 
 		// check if file can be read/written.
-		if (bFileExists == true && bOverwrite == false)
+		if (bFileExists && !bOverwrite)
 		{
-            std::ios_base::openmode mode = std::ios::in | std::ios::out | std::ios::binary;
+		    // Exists and not overwrite: open read-only, and no flush needed
+			m_flushNeeded = false;
+			std::ios_base::openmode mode = std::ios::in | std::ios::binary;
 			m_indexFile.open(sIndexFile.c_str(), mode);
 			m_dataFile.open(sDataFile.c_str(), mode);
 
 			if (m_indexFile.fail() || m_dataFile.fail())
-				throw Tools::IllegalArgumentException("SpatialIndex::DiskStorageManager: Index/Data file cannot be read/written.");
+				throw Tools::IllegalArgumentException("SpatialIndex::DiskStorageManager: Index/Data file cannot be read.");
 		}
 		else
 		{
@@ -284,7 +286,8 @@ DiskStorageManager::DiskStorageManager(Tools::PropertySet& ps) : m_pageSize(0), 
 
 DiskStorageManager::~DiskStorageManager()
 {
-	flush();
+	if (m_flushNeeded)
+	    flush();
 	m_indexFile.close();
 	m_dataFile.close();
 	if (m_buffer != nullptr) delete[] m_buffer;

--- a/src/storagemanager/DiskStorageManager.h
+++ b/src/storagemanager/DiskStorageManager.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2002, Marios Hadjieleftheriou
  *
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
@@ -57,6 +57,7 @@ namespace SpatialIndex
 			id_type m_nextPage;
 			std::set<id_type> m_emptyPages;
 			std::map<id_type, Entry*> m_pageIndex;
+			bool m_flushNeeded = true;
 
 			uint8_t* m_buffer;
 		}; // DiskStorageManager


### PR DESCRIPTION
- Fix #236

Caveat: I'm not in the least familiar with your codebase, I only use the python package `rtree`.
I only build the lib and checked that it compiles fine and ran `ninja test` / `ctest` which appears to run only a single test.

* https://github.com/Toblerity/rtree/issues/247

**Edit**: pretty sure storeByteArray will still try to write to it...