### PR TITLE
No longer key debug print output based on NDEBUG system define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ project(spatialindex
   HOMEPAGE_URL "https://github.com/libspatialindex/libspatialindex"
 )
 
+
 set(SIDX_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}")
 set(SIDX_VERSION_MINOR "${PROJECT_VERSION_MINOR}")
 set(SIDX_VERSION_PATCH "${PROJECT_VERSION_PATCH}")
@@ -25,6 +26,14 @@ set(SIDX_LIB_VERSION "7.0.0")
 set(SIDX_LIB_SOVERSION "7")
 
 include(GNUInstallDirs)
+
+
+IF(NOT CMAKE_BUILD_TYPE)
+    SET(CMAKE_BUILD_TYPE Release CACHE STRING
+        "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel"
+        FORCE)
+ENDIF()
+
 
 message(STATUS
   "Configuring CMake ${CMAKE_VERSION} to build spatialindex ${PROJECT_VERSION}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,12 +201,22 @@ target_compile_options(spatialindex
 target_compile_options(spatialindex_c
   PRIVATE ${SIDX_COMMON_CXX_FLAGS})
 
-set_target_properties( spatialindex PROPERTIES 
-    RUNTIME_OUTPUT_DIRECTORY 
+target_compile_definitions(spatialindex
+    PRIVATE
+        $<$<CONFIG:Debug>:SIDX_DEBUG>
+)
+
+target_compile_definitions(spatialindex_c
+    PRIVATE
+        $<$<CONFIG:Debug>:SIDX_DEBUG>
+)
+
+set_target_properties( spatialindex PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY
     ${CMAKE_BINARY_DIR}/bin)
 
-set_target_properties( spatialindex_c PROPERTIES 
-    RUNTIME_OUTPUT_DIRECTORY 
+set_target_properties( spatialindex_c PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY
     ${CMAKE_BINARY_DIR}/bin)
 
 

--- a/src/mvrtree/Index.cc
+++ b/src/mvrtree/Index.cc
@@ -180,7 +180,7 @@ uint32_t Index::findLeastEnlargement(const TimeRegion& r) const
 		}
 	}
 
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 	if (best == std::numeric_limits<uint32_t>::max())
 	{
 		std::ostringstream s;
@@ -237,7 +237,7 @@ uint32_t Index::findLeastOverlap(const TimeRegion& r) const
 		++cLiveEntries;
 	}
 
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 	if (cLiveEntries == 0)
 	{
 		std::ostringstream s;

--- a/src/mvrtree/Index.cc
+++ b/src/mvrtree/Index.cc
@@ -5,7 +5,7 @@
  * Copyright (c) 2002, Marios Hadjieleftheriou
  *
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
@@ -180,7 +180,7 @@ uint32_t Index::findLeastEnlargement(const TimeRegion& r) const
 		}
 	}
 
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 	if (best == std::numeric_limits<uint32_t>::max())
 	{
 		std::ostringstream s;
@@ -237,7 +237,7 @@ uint32_t Index::findLeastOverlap(const TimeRegion& r) const
 		++cLiveEntries;
 	}
 
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 	if (cLiveEntries == 0)
 	{
 		std::ostringstream s;

--- a/src/mvrtree/MVRTree.cc
+++ b/src/mvrtree/MVRTree.cc
@@ -1337,7 +1337,7 @@ std::ostream& SpatialIndex::MVRTree::operator<<(std::ostream& os, const MVRTree&
 	os << t.m_stats;
 	os << t.printRootInfo();
 
-	#ifndef NDEBUG
+	#ifdef SIDX_DEBUG
 	os 	<< "Leaf pool hits: " << t.m_leafPool.m_hits << std::endl
 		<< "Leaf pool misses: " << t.m_leafPool.m_misses << std::endl
 		<< "Index pool hits: " << t.m_indexPool.m_hits << std::endl

--- a/src/mvrtree/PointerPoolNode.h
+++ b/src/mvrtree/PointerPoolNode.h
@@ -36,7 +36,7 @@ namespace Tools
 	public:
 		explicit PointerPool(uint32_t capacity) : m_capacity(capacity)
 		{
-			#ifndef SIDX_DEBUG
+			#ifdef SIDX_DEBUG
 			m_hits = 0;
 			m_misses = 0;
 			m_pointerCount = 0;
@@ -50,13 +50,13 @@ namespace Tools
 			while (! m_pool.empty())
 			{
 				SpatialIndex::MVRTree::Node* x = m_pool.top(); m_pool.pop();
-				#ifndef SIDX_DEBUG
+				#ifdef SIDX_DEBUG
 				--m_pointerCount;
 				#endif
 				delete x;
 			}
 
-			#ifndef SIDX_DEBUG
+			#ifdef SIDX_DEBUG
 			std::cerr << "Lost pointers: " << m_pointerCount << std::endl;
 			#endif
 		}
@@ -66,13 +66,13 @@ namespace Tools
 			if (! m_pool.empty())
 			{
 				SpatialIndex::MVRTree::Node* p = m_pool.top(); m_pool.pop();
-				#ifndef SIDX_DEBUG
+				#ifdef SIDX_DEBUG
 				++m_hits;
 				#endif
 
 				return PoolPointer<SpatialIndex::MVRTree::Node>(p, this);
 			}
-			#ifndef SIDX_DEBUG
+			#ifdef SIDX_DEBUG
 			else
 			{
 				// fixme: well sort of...
@@ -107,7 +107,7 @@ namespace Tools
 				}
 				else
 				{
-					#ifndef SIDX_DEBUG
+					#ifdef SIDX_DEBUG
 					--m_pointerCount;
 					#endif
 					delete p;
@@ -128,7 +128,7 @@ namespace Tools
 		uint32_t m_capacity;
 		std::stack<SpatialIndex::MVRTree::Node*> m_pool;
 
-	#ifndef SIDX_DEBUG
+	#ifdef SIDX_DEBUG
 	public:
 		uint64_t m_hits;
 		uint64_t m_misses;

--- a/src/mvrtree/PointerPoolNode.h
+++ b/src/mvrtree/PointerPoolNode.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2002, Marios Hadjieleftheriou
  *
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
@@ -36,7 +36,7 @@ namespace Tools
 	public:
 		explicit PointerPool(uint32_t capacity) : m_capacity(capacity)
 		{
-			#ifndef NDEBUG
+			#ifndef SIDX_DEBUG
 			m_hits = 0;
 			m_misses = 0;
 			m_pointerCount = 0;
@@ -50,13 +50,13 @@ namespace Tools
 			while (! m_pool.empty())
 			{
 				SpatialIndex::MVRTree::Node* x = m_pool.top(); m_pool.pop();
-				#ifndef NDEBUG
+				#ifndef SIDX_DEBUG
 				--m_pointerCount;
 				#endif
 				delete x;
 			}
 
-			#ifndef NDEBUG
+			#ifndef SIDX_DEBUG
 			std::cerr << "Lost pointers: " << m_pointerCount << std::endl;
 			#endif
 		}
@@ -66,13 +66,13 @@ namespace Tools
 			if (! m_pool.empty())
 			{
 				SpatialIndex::MVRTree::Node* p = m_pool.top(); m_pool.pop();
-				#ifndef NDEBUG
+				#ifndef SIDX_DEBUG
 				++m_hits;
 				#endif
 
 				return PoolPointer<SpatialIndex::MVRTree::Node>(p, this);
 			}
-			#ifndef NDEBUG
+			#ifndef SIDX_DEBUG
 			else
 			{
 				// fixme: well sort of...
@@ -107,7 +107,7 @@ namespace Tools
 				}
 				else
 				{
-					#ifndef NDEBUG
+					#ifndef SIDX_DEBUG
 					--m_pointerCount;
 					#endif
 					delete p;
@@ -128,7 +128,7 @@ namespace Tools
 		uint32_t m_capacity;
 		std::stack<SpatialIndex::MVRTree::Node*> m_pool;
 
-	#ifndef NDEBUG
+	#ifndef SIDX_DEBUG
 	public:
 		uint64_t m_hits;
 		uint64_t m_misses;

--- a/src/rtree/BulkLoader.cc
+++ b/src/rtree/BulkLoader.cc
@@ -333,7 +333,7 @@ void BulkLoader::bulkLoadUsingSTR(
 	NodePtr n = pTree->readNode(pTree->m_rootID);
 	pTree->deleteNode(n.get());
 
-	#ifndef SIDX_DEBUG
+	#ifdef SIDX_DEBUG
 	std::cerr << "RTree::BulkLoader: Sorting data." << std::endl;
 	#endif
 
@@ -360,7 +360,7 @@ void BulkLoader::bulkLoadUsingSTR(
 
 	while (true)
 	{
-		#ifndef SIDX_DEBUG
+		#ifdef SIDX_DEBUG
 		std::cerr << "RTree::BulkLoader: Building level " << level << std::endl;
 		#endif
 

--- a/src/rtree/BulkLoader.cc
+++ b/src/rtree/BulkLoader.cc
@@ -333,7 +333,7 @@ void BulkLoader::bulkLoadUsingSTR(
 	NodePtr n = pTree->readNode(pTree->m_rootID);
 	pTree->deleteNode(n.get());
 
-	#ifndef NDEBUG
+	#ifndef SIDX_DEBUG
 	std::cerr << "RTree::BulkLoader: Sorting data." << std::endl;
 	#endif
 
@@ -360,7 +360,7 @@ void BulkLoader::bulkLoadUsingSTR(
 
 	while (true)
 	{
-		#ifndef NDEBUG
+		#ifndef SIDX_DEBUG
 		std::cerr << "RTree::BulkLoader: Building level " << level << std::endl;
 		#endif
 

--- a/src/rtree/PointerPoolNode.h
+++ b/src/rtree/PointerPoolNode.h
@@ -38,7 +38,7 @@ namespace Tools
 	public:
 		explicit PointerPool(uint32_t capacity) : m_capacity(capacity)
 		{
-			#ifndef SIDX_DEBUG
+			#ifdef SIDX_DEBUG
 			m_hits = 0;
 			m_misses = 0;
 			m_pointerCount = 0;
@@ -52,13 +52,13 @@ namespace Tools
 			while (! m_pool.empty())
 			{
 				RTree::Node* x = m_pool.top(); m_pool.pop();
-				#ifndef SIDX_DEBUG
+				#ifdef SIDX_DEBUG
 				--m_pointerCount;
 				#endif
 				delete x;
 			}
 
-			#ifndef SIDX_DEBUG
+			#ifdef SIDX_DEBUG
 			std::cerr << "Lost pointers: " << m_pointerCount << std::endl;
 			#endif
 		}
@@ -68,13 +68,13 @@ namespace Tools
 			if (! m_pool.empty())
 			{
 				RTree::Node* p = m_pool.top(); m_pool.pop();
-				#ifndef SIDX_DEBUG
+				#ifdef SIDX_DEBUG
 				++m_hits;
 				#endif
 
 				return PoolPointer<RTree::Node>(p, this);
 			}
-			#ifndef SIDX_DEBUG
+			#ifdef SIDX_DEBUG
 			else
 			{
 				// fixme: well sort of...
@@ -112,7 +112,7 @@ namespace Tools
 				}
 				else
 				{
-					#ifndef SIDX_DEBUG
+					#ifdef SIDX_DEBUG
 					--m_pointerCount;
 					#endif
 					delete p;
@@ -133,7 +133,7 @@ namespace Tools
 		uint32_t m_capacity;
 		std::stack<RTree::Node*> m_pool;
 
-	#ifndef SIDX_DEBUG
+	#ifdef SIDX_DEBUG
 	public:
 		uint64_t m_hits;
 		uint64_t m_misses;

--- a/src/rtree/PointerPoolNode.h
+++ b/src/rtree/PointerPoolNode.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2002, Marios Hadjieleftheriou
  *
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
@@ -38,7 +38,7 @@ namespace Tools
 	public:
 		explicit PointerPool(uint32_t capacity) : m_capacity(capacity)
 		{
-			#ifndef NDEBUG
+			#ifndef SIDX_DEBUG
 			m_hits = 0;
 			m_misses = 0;
 			m_pointerCount = 0;
@@ -52,13 +52,13 @@ namespace Tools
 			while (! m_pool.empty())
 			{
 				RTree::Node* x = m_pool.top(); m_pool.pop();
-				#ifndef NDEBUG
+				#ifndef SIDX_DEBUG
 				--m_pointerCount;
 				#endif
 				delete x;
 			}
 
-			#ifndef NDEBUG
+			#ifndef SIDX_DEBUG
 			std::cerr << "Lost pointers: " << m_pointerCount << std::endl;
 			#endif
 		}
@@ -68,13 +68,13 @@ namespace Tools
 			if (! m_pool.empty())
 			{
 				RTree::Node* p = m_pool.top(); m_pool.pop();
-				#ifndef NDEBUG
+				#ifndef SIDX_DEBUG
 				++m_hits;
 				#endif
 
 				return PoolPointer<RTree::Node>(p, this);
 			}
-			#ifndef NDEBUG
+			#ifndef SIDX_DEBUG
 			else
 			{
 				// fixme: well sort of...
@@ -112,7 +112,7 @@ namespace Tools
 				}
 				else
 				{
-					#ifndef NDEBUG
+					#ifndef SIDX_DEBUG
 					--m_pointerCount;
 					#endif
 					delete p;
@@ -133,7 +133,7 @@ namespace Tools
 		uint32_t m_capacity;
 		std::stack<RTree::Node*> m_pool;
 
-	#ifndef NDEBUG
+	#ifndef SIDX_DEBUG
 	public:
 		uint64_t m_hits;
 		uint64_t m_misses;

--- a/src/rtree/RTree.cc
+++ b/src/rtree/RTree.cc
@@ -1334,7 +1334,7 @@ SpatialIndex::id_type SpatialIndex::RTree::RTree::writeNode(Node* n)
 		n->m_identifier = page;
 		++(m_stats.m_u32Nodes);
 
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 		try
 		{
 			m_stats.m_nodesInLevel[n->m_level] = m_stats.m_nodesInLevel.at(n->m_level) + 1;
@@ -1563,7 +1563,7 @@ std::ostream& SpatialIndex::RTree::operator<<(std::ostream& os, const RTree& t)
 		os	<< "Utilization: " << 100 * t.m_stats.getNumberOfData() / (t.m_stats.getNumberOfNodesInLevel(0) * t.m_leafCapacity) << "%" << std::endl
 			<< t.m_stats;
 
-	#ifndef NDEBUG
+	#ifdef SIDX_DEBUG
 	os	<< "Leaf pool hits: " << t.m_leafPool.m_hits << std::endl
 		<< "Leaf pool misses: " << t.m_leafPool.m_misses << std::endl
 		<< "Index pool hits: " << t.m_indexPool.m_hits << std::endl

--- a/src/rtree/RTree.cc
+++ b/src/rtree/RTree.cc
@@ -1334,7 +1334,7 @@ SpatialIndex::id_type SpatialIndex::RTree::RTree::writeNode(Node* n)
 		n->m_identifier = page;
 		++(m_stats.m_u32Nodes);
 
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 		try
 		{
 			m_stats.m_nodesInLevel[n->m_level] = m_stats.m_nodesInLevel.at(n->m_level) + 1;

--- a/src/spatialindex/MovingRegion.cc
+++ b/src/spatialindex/MovingRegion.cc
@@ -183,7 +183,7 @@ void MovingRegion::initialize(
 
 	if (m_endTime <= m_startTime) throw Tools::IllegalArgumentException("MovingRegion: Cannot support degenerate time intervals.");
 
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 	for (uint32_t cDim = 0; cDim < m_dimension; ++cDim)
 	{
 		if (pLow[cDim] > pHigh[cDim]) throw Tools::IllegalArgumentException("MovingRegion: Low point has larger coordinates than High point.");
@@ -982,14 +982,14 @@ double MovingRegion::getIntersectingAreaInTime(const IInterval& ivI, const Movin
 
 	// add up the total area of the intersecting pieces.
 	double area = 0.0;
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 	double _t = -std::numeric_limits<double>::max();
 #endif
 
 	while (! pq.empty())
 	{
 		c = pq.top(); pq.pop();
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 		assert(_t <= c.m_t);
 		_t = c.m_t;
 #endif

--- a/src/spatialindex/MovingRegion.cc
+++ b/src/spatialindex/MovingRegion.cc
@@ -183,7 +183,7 @@ void MovingRegion::initialize(
 
 	if (m_endTime <= m_startTime) throw Tools::IllegalArgumentException("MovingRegion: Cannot support degenerate time intervals.");
 
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 	for (uint32_t cDim = 0; cDim < m_dimension; ++cDim)
 	{
 		if (pLow[cDim] > pHigh[cDim]) throw Tools::IllegalArgumentException("MovingRegion: Low point has larger coordinates than High point.");
@@ -982,14 +982,14 @@ double MovingRegion::getIntersectingAreaInTime(const IInterval& ivI, const Movin
 
 	// add up the total area of the intersecting pieces.
 	double area = 0.0;
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 	double _t = -std::numeric_limits<double>::max();
 #endif
 
 	while (! pq.empty())
 	{
 		c = pq.top(); pq.pop();
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 		assert(_t <= c.m_t);
 		_t = c.m_t;
 #endif

--- a/src/spatialindex/Region.cc
+++ b/src/spatialindex/Region.cc
@@ -5,7 +5,7 @@
  * Copyright (c) 2004, Marios Hadjieleftheriou
  *
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
@@ -61,7 +61,7 @@ void Region::initialize(const double* pLow, const double* pHigh, uint32_t dimens
 	m_pLow = nullptr;
 	m_dimension = dimension;
 
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
     for (uint32_t cDim = 0; cDim < m_dimension; ++cDim)
     {
      if ((pLow[cDim] > pHigh[cDim]))
@@ -295,7 +295,7 @@ bool Region::touchesRegion(const Region& r) const
 		throw Tools::IllegalArgumentException(
 			"Region::touchesRegion: Regions have different number of dimensions."
 		);
-	
+
 	for (uint32_t i = 0; i < m_dimension; ++i)
 	{
 		if (
@@ -361,11 +361,11 @@ bool Region::intersectsLineSegment(const LineSegment& in) const
     // Points/LineSegment for the segment
     Point p1 = Point(in.m_pStartPoint, 2);
     Point p2 = Point(in.m_pEndPoint, 2);
-    
+
 
     //Check whether either or both the endpoints are within the region OR
     //whether any of the bounding segments of the Region intersect the segment
-    return (containsPoint(p1) || containsPoint(p2) || 
+    return (containsPoint(p1) || containsPoint(p2) ||
             in.intersectsShape(LineSegment(ll, ul)) || in.intersectsShape(LineSegment(ul, ur)) ||
             in.intersectsShape(LineSegment(ur, lr)) || in.intersectsShape(LineSegment(lr, ll)));
 

--- a/src/spatialindex/Region.cc
+++ b/src/spatialindex/Region.cc
@@ -61,7 +61,7 @@ void Region::initialize(const double* pLow, const double* pHigh, uint32_t dimens
 	m_pLow = nullptr;
 	m_dimension = dimension;
 
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
     for (uint32_t cDim = 0; cDim < m_dimension; ++cDim)
     {
      if ((pLow[cDim] > pHigh[cDim]))

--- a/src/tprtree/Index.cc
+++ b/src/tprtree/Index.cc
@@ -321,7 +321,7 @@ void Index::adjustTree(Node* n, std::stack<id_type>& pathBuffer)
 		}
 	//}
 
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 	for (uint32_t cChild = 0; cChild < m_children; ++cChild)
 	{
 		assert(m_nodeMBR.containsRegionAfterTime(m_pTree->m_currentTime, *(m_ptrMBR[cChild])) == true);
@@ -382,7 +382,7 @@ void Index::adjustTree(Node* n1, Node* n2, std::stack<id_type>& pathBuffer, uint
 		}
 	//}
 
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 	for (uint32_t cChild = 0; cChild < m_children; ++cChild)
 	{
 		assert(m_nodeMBR.containsRegionAfterTime(m_pTree->m_currentTime, *(m_ptrMBR[cChild])) == true);

--- a/src/tprtree/Index.cc
+++ b/src/tprtree/Index.cc
@@ -5,7 +5,7 @@
  * Copyright (c) 2002, Marios Hadjieleftheriou
  *
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
@@ -321,7 +321,7 @@ void Index::adjustTree(Node* n, std::stack<id_type>& pathBuffer)
 		}
 	//}
 
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 	for (uint32_t cChild = 0; cChild < m_children; ++cChild)
 	{
 		assert(m_nodeMBR.containsRegionAfterTime(m_pTree->m_currentTime, *(m_ptrMBR[cChild])) == true);
@@ -382,7 +382,7 @@ void Index::adjustTree(Node* n1, Node* n2, std::stack<id_type>& pathBuffer, uint
 		}
 	//}
 
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 	for (uint32_t cChild = 0; cChild < m_children; ++cChild)
 	{
 		assert(m_nodeMBR.containsRegionAfterTime(m_pTree->m_currentTime, *(m_ptrMBR[cChild])) == true);

--- a/src/tprtree/Node.cc
+++ b/src/tprtree/Node.cc
@@ -5,7 +5,7 @@
  * Copyright (c) 2002, Marios Hadjieleftheriou
  *
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
@@ -376,7 +376,7 @@ bool Node::insertEntry(uint32_t dataLength, uint8_t* pData, MovingRegion& mbr, i
 		}
 	}
 
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 	for (uint32_t cChild = 0; cChild < m_children; ++cChild)
 	{
 		assert(m_nodeMBR.containsRegionAfterTime(m_nodeMBR.m_startTime, *(m_ptrMBR[cChild])));
@@ -434,7 +434,7 @@ void Node::deleteEntry(uint32_t index)
 			m_nodeMBR.m_pHigh[cDim] += 2.0 * std::numeric_limits<double>::epsilon();
 		}
 
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 		for (uint32_t cChild = 0; cChild < m_children; ++cChild)
 		{
 			assert(m_nodeMBR.containsRegionAfterTime(m_pTree->m_currentTime, *(m_ptrMBR[cChild])) == true);
@@ -460,9 +460,9 @@ bool Node::insertData(uint32_t dataLength, uint8_t* pData, MovingRegion& mbr, id
 
 		return bNeedToAdjust;
 	}
-	else if (false && 
-		     m_pTree->m_treeVariant == TPRV_RSTAR && 
-			 !pathBuffer.empty() && 
+	else if (false &&
+		     m_pTree->m_treeVariant == TPRV_RSTAR &&
+			 !pathBuffer.empty() &&
 			 overflowTable[m_level] == 0)
 	{
 		overflowTable[m_level] = 1;
@@ -559,7 +559,7 @@ bool Node::insertData(uint32_t dataLength, uint8_t* pData, MovingRegion& mbr, id
 			m_nodeMBR.m_pHigh[cDim] += 2.0 * std::numeric_limits<double>::epsilon();
 		}
 
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 		for (uint32_t cChild = 0; cChild < m_children; ++cChild)
 		{
 			assert(m_nodeMBR.containsRegionAfterTime(m_nodeMBR.m_startTime, *(m_ptrMBR[cChild])));
@@ -604,7 +604,7 @@ bool Node::insertData(uint32_t dataLength, uint8_t* pData, MovingRegion& mbr, id
 			n->m_identifier = -1;
 			nn->m_identifier = -1;
 
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 			for (uint32_t cChild = 0; cChild < n->m_children; ++cChild)
 			{
 				assert(n->m_nodeMBR.containsRegionAfterTime(n->m_nodeMBR.m_startTime, *(n->m_ptrMBR[cChild])) == true);
@@ -647,7 +647,7 @@ bool Node::insertData(uint32_t dataLength, uint8_t* pData, MovingRegion& mbr, id
 			n->m_identifier = m_identifier;
 			nn->m_identifier = -1;
 
-#ifndef NDEBUG
+#ifndef SIDX_DEBUG
 			for (uint32_t cChild = 0; cChild < n->m_children; ++cChild)
 			{
 				assert(n->m_nodeMBR.containsRegionAfterTime(n->m_nodeMBR.m_startTime, *(n->m_ptrMBR[cChild])) == true);

--- a/src/tprtree/Node.cc
+++ b/src/tprtree/Node.cc
@@ -376,7 +376,7 @@ bool Node::insertEntry(uint32_t dataLength, uint8_t* pData, MovingRegion& mbr, i
 		}
 	}
 
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 	for (uint32_t cChild = 0; cChild < m_children; ++cChild)
 	{
 		assert(m_nodeMBR.containsRegionAfterTime(m_nodeMBR.m_startTime, *(m_ptrMBR[cChild])));
@@ -434,7 +434,7 @@ void Node::deleteEntry(uint32_t index)
 			m_nodeMBR.m_pHigh[cDim] += 2.0 * std::numeric_limits<double>::epsilon();
 		}
 
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 		for (uint32_t cChild = 0; cChild < m_children; ++cChild)
 		{
 			assert(m_nodeMBR.containsRegionAfterTime(m_pTree->m_currentTime, *(m_ptrMBR[cChild])) == true);
@@ -559,7 +559,7 @@ bool Node::insertData(uint32_t dataLength, uint8_t* pData, MovingRegion& mbr, id
 			m_nodeMBR.m_pHigh[cDim] += 2.0 * std::numeric_limits<double>::epsilon();
 		}
 
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 		for (uint32_t cChild = 0; cChild < m_children; ++cChild)
 		{
 			assert(m_nodeMBR.containsRegionAfterTime(m_nodeMBR.m_startTime, *(m_ptrMBR[cChild])));
@@ -604,7 +604,7 @@ bool Node::insertData(uint32_t dataLength, uint8_t* pData, MovingRegion& mbr, id
 			n->m_identifier = -1;
 			nn->m_identifier = -1;
 
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 			for (uint32_t cChild = 0; cChild < n->m_children; ++cChild)
 			{
 				assert(n->m_nodeMBR.containsRegionAfterTime(n->m_nodeMBR.m_startTime, *(n->m_ptrMBR[cChild])) == true);
@@ -647,7 +647,7 @@ bool Node::insertData(uint32_t dataLength, uint8_t* pData, MovingRegion& mbr, id
 			n->m_identifier = m_identifier;
 			nn->m_identifier = -1;
 
-#ifndef SIDX_DEBUG
+#ifdef SIDX_DEBUG
 			for (uint32_t cChild = 0; cChild < n->m_children; ++cChild)
 			{
 				assert(n->m_nodeMBR.containsRegionAfterTime(n->m_nodeMBR.m_startTime, *(n->m_ptrMBR[cChild])) == true);

--- a/src/tprtree/PointerPoolNode.h
+++ b/src/tprtree/PointerPoolNode.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2002, Marios Hadjieleftheriou
  *
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
@@ -37,7 +37,7 @@ namespace Tools
 	public:
 		explicit PointerPool(uint32_t capacity) : m_capacity(capacity)
 		{
-			#ifndef NDEBUG
+			#ifndef SIDX_DEBUG
 			m_hits = 0;
 			m_misses = 0;
 			m_pointerCount = 0;
@@ -51,13 +51,13 @@ namespace Tools
 			while (! m_pool.empty())
 			{
 				TPRTree::Node* x = m_pool.top(); m_pool.pop();
-				#ifndef NDEBUG
+				#ifndef SIDX_DEBUG
 				--m_pointerCount;
 				#endif
 				delete x;
 			}
 
-			#ifndef NDEBUG
+			#ifndef SIDX_DEBUG
 			std::cerr << "Lost pointers: " << m_pointerCount << std::endl;
 			#endif
 		}
@@ -67,13 +67,13 @@ namespace Tools
 			if (! m_pool.empty())
 			{
 				TPRTree::Node* p = m_pool.top(); m_pool.pop();
-				#ifndef NDEBUG
+				#ifndef SIDX_DEBUG
 				++m_hits;
 				#endif
 
 				return PoolPointer<TPRTree::Node>(p, this);
 			}
-			#ifndef NDEBUG
+			#ifndef SIDX_DEBUG
 			else
 			{
 				// fixme: well sort of...
@@ -108,7 +108,7 @@ namespace Tools
 				}
 				else
 				{
-					#ifndef NDEBUG
+					#ifndef SIDX_DEBUG
 					--m_pointerCount;
 					#endif
 					delete p;
@@ -129,7 +129,7 @@ namespace Tools
 		uint32_t m_capacity;
 		std::stack<TPRTree::Node*> m_pool;
 
-	#ifndef NDEBUG
+	#ifndef SIDX_DEBUG
 	public:
 		uint64_t m_hits;
 		uint64_t m_misses;

--- a/src/tprtree/PointerPoolNode.h
+++ b/src/tprtree/PointerPoolNode.h
@@ -37,7 +37,7 @@ namespace Tools
 	public:
 		explicit PointerPool(uint32_t capacity) : m_capacity(capacity)
 		{
-			#ifndef SIDX_DEBUG
+			#ifdef SIDX_DEBUG
 			m_hits = 0;
 			m_misses = 0;
 			m_pointerCount = 0;
@@ -51,13 +51,13 @@ namespace Tools
 			while (! m_pool.empty())
 			{
 				TPRTree::Node* x = m_pool.top(); m_pool.pop();
-				#ifndef SIDX_DEBUG
+				#ifdef SIDX_DEBUG
 				--m_pointerCount;
 				#endif
 				delete x;
 			}
 
-			#ifndef SIDX_DEBUG
+			#ifdef SIDX_DEBUG
 			std::cerr << "Lost pointers: " << m_pointerCount << std::endl;
 			#endif
 		}
@@ -67,13 +67,13 @@ namespace Tools
 			if (! m_pool.empty())
 			{
 				TPRTree::Node* p = m_pool.top(); m_pool.pop();
-				#ifndef SIDX_DEBUG
+				#ifdef SIDX_DEBUG
 				++m_hits;
 				#endif
 
 				return PoolPointer<TPRTree::Node>(p, this);
 			}
-			#ifndef SIDX_DEBUG
+			#ifdef SIDX_DEBUG
 			else
 			{
 				// fixme: well sort of...
@@ -108,7 +108,7 @@ namespace Tools
 				}
 				else
 				{
-					#ifndef SIDX_DEBUG
+					#ifdef SIDX_DEBUG
 					--m_pointerCount;
 					#endif
 					delete p;
@@ -129,7 +129,7 @@ namespace Tools
 		uint32_t m_capacity;
 		std::stack<TPRTree::Node*> m_pool;
 
-	#ifndef SIDX_DEBUG
+	#ifdef SIDX_DEBUG
 	public:
 		uint64_t m_hits;
 		uint64_t m_misses;

--- a/src/tprtree/TPRTree.cc
+++ b/src/tprtree/TPRTree.cc
@@ -1098,7 +1098,7 @@ SpatialIndex::id_type SpatialIndex::TPRTree::TPRTree::writeNode(Node* n)
 		n->m_identifier = page;
 		++(m_stats.m_nodes);
 
-#ifndef NDEBUG
+#ifdef SIDX_DEBUG
 		try
 		{
 			m_stats.m_nodesInLevel[n->m_level] = m_stats.m_nodesInLevel.at(n->m_level) + 1;
@@ -1264,7 +1264,7 @@ std::ostream& SpatialIndex::TPRTree::operator<<(std::ostream& os, const TPRTree&
 		os	<< "Utilization: " << 100 * t.m_stats.getNumberOfData() / (t.m_stats.getNumberOfNodesInLevel(0) * t.m_leafCapacity) << "%" << std::endl
 			<< t.m_stats;
 
-	#ifndef NDEBUG
+	#ifdef SIDX_DEBUG
 	os	<< "Leaf pool hits: " << t.m_leafPool.m_hits << std::endl
 		<< "Leaf pool misses: " << t.m_leafPool.m_misses << std::endl
 		<< "Index pool hits: " << t.m_indexPool.m_hits << std::endl


### PR DESCRIPTION
The library would often pick up `NDEBUG` defines from default CFLAG/CXXFLAG values depending on whether or not the BUILD_TYPE has been set. This changes the entire behavior to require an explicit opt-in by the user choosing a debug build type from CMake and guarding with a `SIDX_DEBUG` define.