### PR TITLE
Add configuration for codespell and correct typos

### DIFF
--- a/.codespell.ignore
+++ b/.codespell.ignore
@@ -1,0 +1,4 @@
+cLen
+IInterval
+IndexS
+ot

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./test/gtest/gtest-1.14.0
+ignore-words = .codespell.ignore

--- a/ChangeLog
+++ b/ChangeLog
@@ -88,7 +88,7 @@
 2018-04-26
 	* Howard Butler <howard@hobu.co> Merge pull request #114 from michael-herwig/master (10:58:17)
 	* Michael Herwig <michael.herwig@hotmail.de> added summary to changelog (05:34:40)
-	* Michael Herwig <michael.herwig@hotmail.de> Added silent tr1 depecreation flag vor msvc compiler >= 1900 (05:30:27)
+	* Michael Herwig <michael.herwig@hotmail.de> Added silent tr1 depecreation flag for msvc compiler >= 1900 (05:30:27)
 	* Michael Herwig <michael.herwig@hotmail.de> Added <cinttypes> include for proper compilation using msvc15 (05:23:48)
 	* Michael Herwig <michael.herwig@hotmail.de> Added cmake option for conditional test integration (05:19:21)
 
@@ -309,7 +309,7 @@
 2014-07-12
 	* Howard Butler <hobu.inc@gmail.com> add BUILD_WITH_INSTALL_RPATH target property for OSX (23:59:03)
 	* Howard Butler <hobu.inc@gmail.com> CMake config quoting #27 (23:50:05)
-	* Howard Butler <hobu.inc@gmail.com> FSF postal adress update #5 (23:38:24)
+	* Howard Butler <hobu.inc@gmail.com> FSF postal address update #5 (23:38:24)
 	* Howard Butler <hobu.inc@gmail.com> support wide character as possible tools::Variant type -- doesn't work yet though (23:32:19)
 	* Howard Butler <hobu.inc@gmail.com> add VT_PWCHAR to support wide character pointer for the Variant type (23:31:15)
 	* Howard Butler <hobu.inc@gmail.com> add MSVC 2013 and 2014 defns (23:27:45)
@@ -436,7 +436,7 @@
 	* Howard Butler <hobu.inc@gmail.com> Merge pull request #8 from booo/master (10:03:27)
 
 2012-07-14
-	* Marios Hadjieleftheriou <mhadji@gmail.com> Reverted to using pthread mutex and exlusively lock all queries, since fine grain locking using spinlocks was too slow. (09:57:39)
+	* Marios Hadjieleftheriou <mhadji@gmail.com> Reverted to using pthread mutex and exclusively lock all queries, since fine grain locking using spinlocks was too slow. (09:57:39)
 	* Marios Hadjieleftheriou <mhadji@gmail.com> Reverted to using pthread mutex for all queries, since fine grain locking using spinlocks was too slow. (09:52:34)
 
 2012-07-10
@@ -604,7 +604,7 @@
 2010-04-12
 	* Howard Butler <hobu.inc@gmail.com> update ChangeLog (14:56:52)
 	* Marios Hadjieleftheriou <mhadji@gmail.com>  (12:17:47)
-	* Marios Hadjieleftheriou <mhadji@gmail.com> Fixed rtree/BulkLoader infinit loop bug (12:07:13)
+	* Marios Hadjieleftheriou <mhadji@gmail.com> Fixed rtree/BulkLoader infinite loop bug (12:07:13)
 
 2010-03-31
 	* Howard Butler <hobu.inc@gmail.com> format and layout normalization (10:33:43)
@@ -647,7 +647,7 @@
 	* Howard Butler <hobu.inc@gmail.com> only #include <limits> where needed, and not in the global Tools.h file (14:08:16)
 
 2009-10-30
-	* Howard Butler <hobu.inc@gmail.com> remove <cmath> <limits> and <climits> from Tools.h and include them seperately in each file that needs them (12:09:14)
+	* Howard Butler <hobu.inc@gmail.com> remove <cmath> <limits> and <climits> from Tools.h and include them separately in each file that needs them (12:09:14)
 	* Howard Butler <hobu.inc@gmail.com> define to denote we're C API (11:37:11)
 	* Howard Butler <hobu.inc@gmail.com> add a newline (10:03:47)
 

--- a/docs/doxygen/doxygen.conf
+++ b/docs/doxygen/doxygen.conf
@@ -860,7 +860,7 @@ HTML_FILE_EXTENSION    = .html
 # standard header. Note that when using a custom header you are responsible
 #  for the proper inclusion of any scripts and style sheets that doxygen
 # needs, which is dependent on the configuration options used.
-# It is adviced to generate a default header using "doxygen -w html
+# It is advised to generate a default header using "doxygen -w html
 # header.html footer.html stylesheet.css YourConfigFile" and then modify
 # that header. Note that the header is subject to change so you typically
 # have to redo this when upgrading to a newer version of doxygen or when

--- a/src/capi/sidx_api.cc
+++ b/src/capi/sidx_api.cc
@@ -37,7 +37,7 @@
 # define LAST_ERROR_BUFFER_SIZE 1024
 /*
  * __thread is gcc specific extension for thread-local storage, that does not allow complex
- * constructor. We can't use any of std containers for storing mutliple error messages, but we
+ * constructor. We can't use any of std containers for storing multiple error messages, but we
  * could at least get latest error message safely. The error count will be at most 1. The finer
  * solution would be to use thread-local storage from C++11, but since this library is compiled
  * with C++98 flag, this option is not available yet.

--- a/src/mvrtree/MVRTree.cc
+++ b/src/mvrtree/MVRTree.cc
@@ -304,7 +304,7 @@ bool SpatialIndex::MVRTree::MVRTree::deleteData(const IShape& shape, id_type id)
 
 void SpatialIndex::MVRTree::MVRTree::internalNodesQuery(const IShape& /* query */, IVisitor& /* v */)
 {
-	throw Tools::IllegalStateException("internalNodesQuery: not impelmented yet.");
+	throw Tools::IllegalStateException("internalNodesQuery: not implemented yet.");
 }
 
 void SpatialIndex::MVRTree::MVRTree::containsWhatQuery(const IShape& query, IVisitor& v)
@@ -330,7 +330,7 @@ void SpatialIndex::MVRTree::MVRTree::pointLocationQuery(const Point& query, IVis
 
 void SpatialIndex::MVRTree::MVRTree::nearestNeighborQuery(uint32_t, const IShape&, IVisitor&, INearestNeighborComparator&)
 {
-	throw Tools::IllegalStateException("nearestNeighborQuery: not impelmented yet.");
+	throw Tools::IllegalStateException("nearestNeighborQuery: not implemented yet.");
 }
 
 void SpatialIndex::MVRTree::MVRTree::nearestNeighborQuery(uint32_t k, const IShape& query, IVisitor& v)
@@ -342,7 +342,7 @@ void SpatialIndex::MVRTree::MVRTree::nearestNeighborQuery(uint32_t k, const ISha
 
 void SpatialIndex::MVRTree::MVRTree::selfJoinQuery(const IShape&, IVisitor&)
 {
-	throw Tools::IllegalStateException("selfJoinQuery: not impelmented yet.");
+	throw Tools::IllegalStateException("selfJoinQuery: not implemented yet.");
 }
 
 void SpatialIndex::MVRTree::MVRTree::queryStrategy(IQueryStrategy& qs)

--- a/src/mvrtree/MVRTree.h
+++ b/src/mvrtree/MVRTree.h
@@ -48,7 +48,7 @@ namespace SpatialIndex
 			MVRTree(IStorageManager&, Tools::PropertySet&);
 				// String                   Value     Description
 				// ----------------------------------------------
-				// IndexIndentifier         VT_LONG   If specified an existing index will be openened from the supplied
+				// IndexIndentifier         VT_LONG   If specified an existing index will be opened from the supplied
 				//                                    storage manager with the given index id. Behaviour is unspecified
 				//                                    if the index id or the storage manager are incorrect.
 				// Dimension                VT_ULONG  Dimensionality of the data that will be inserted.
@@ -126,7 +126,7 @@ namespace SpatialIndex
 				// for Points and Rectangles, Section 4.1]
 
 			double m_splitDistributionFactor;
-				// The R*-Tree 'm' constant, for calculating spliting distributions.
+				// The R*-Tree 'm' constant, for calculating splitting distributions.
 				// [Beckmann, Kriegel, Schneider, Seeger 'The R*-tree: An efficient and Robust Access Method
 				// for Points and Rectangles, Section 4.2]
 

--- a/src/mvrtree/Node.cc
+++ b/src/mvrtree/Node.cc
@@ -1099,7 +1099,7 @@ void Node::rtreeSplit(
 	{
 		if (minimumLoad - group1.size() == cRemaining)
 		{
-			// all remaining entries must be assigned to group1 to comply with minimun load requirement.
+			// all remaining entries must be assigned to group1 to comply with minimum load requirement.
 			for (cChild = 0; cChild < cTotal; ++cChild)
 			{
 				if (mask[cChild] == 0)
@@ -1112,7 +1112,7 @@ void Node::rtreeSplit(
 		}
 		else if (minimumLoad - group2.size() == cRemaining)
 		{
-			// all remaining entries must be assigned to group2 to comply with minimun load requirement.
+			// all remaining entries must be assigned to group2 to comply with minimum load requirement.
 			for (cChild = 0; cChild < cTotal; ++cChild)
 			{
 				if (mask[cChild] == 0)

--- a/src/mvrtree/Statistics.cc
+++ b/src/mvrtree/Statistics.cc
@@ -176,8 +176,8 @@ std::ostream& SpatialIndex::MVRTree::operator<<(std::ostream& os, const Statisti
 		<< "Number of live data: " << s.m_u64Data << std::endl
 		<< "Total number of data: " << s.m_u64TotalData << std::endl
 		<< "Number of nodes: " << s.m_u32Nodes << std::endl
-		<< "Numer of dead index nodes: " << s.m_u32DeadIndexNodes << std::endl
-		<< "Numer of dead leaf nodes: " << s.m_u32DeadLeafNodes << std::endl;
+		<< "Number of dead index nodes: " << s.m_u32DeadIndexNodes << std::endl
+		<< "Number of dead leaf nodes: " << s.m_u32DeadLeafNodes << std::endl;
 
 	for (size_t cTree = 0; cTree < s.m_treeHeight.size(); ++cTree)
 	{

--- a/src/rtree/Node.cc
+++ b/src/rtree/Node.cc
@@ -454,7 +454,7 @@ bool Node::insertData(uint32_t dataLength, uint8_t* pData, Region& mbr, id_type 
 
 		m_pTree->writeNode(this);
 
-		// Divertion from R*-Tree algorithm here. First adjust
+		// Diversion from R*-Tree algorithm here. First adjust
 		// the path to the root, then start reinserts, to avoid complicated handling
 		// of changes to the same node from multiple insertions.
 		id_type cParent = pathBuffer.top(); pathBuffer.pop();
@@ -640,7 +640,7 @@ void Node::rtreeSplit(uint32_t dataLength, uint8_t* pData, Region& mbr, id_type 
 	{
 		if (minimumLoad - group1.size() == cRemaining)
 		{
-			// all remaining entries must be assigned to group1 to comply with minimun load requirement.
+			// all remaining entries must be assigned to group1 to comply with minimum load requirement.
 			for (u32Child = 0; u32Child < m_capacity + 1; ++u32Child)
 			{
 				if (mask[u32Child] == 0)
@@ -653,7 +653,7 @@ void Node::rtreeSplit(uint32_t dataLength, uint8_t* pData, Region& mbr, id_type 
 		}
 		else if (minimumLoad - group2.size() == cRemaining)
 		{
-			// all remaining entries must be assigned to group2 to comply with minimun load requirement.
+			// all remaining entries must be assigned to group2 to comply with minimum load requirement.
 			for (u32Child = 0; u32Child < m_capacity + 1; ++u32Child)
 			{
 				if (mask[u32Child] == 0)

--- a/src/rtree/RTree.h
+++ b/src/rtree/RTree.h
@@ -44,7 +44,7 @@ namespace SpatialIndex
 			RTree(IStorageManager&, Tools::PropertySet&);
 				// String                   Value     Description
 				// ----------------------------------------------
-				// IndexIndentifier         VT_LONG   If specified an existing index will be openened from the supplied
+				// IndexIndentifier         VT_LONG   If specified an existing index will be opened from the supplied
 				//                          storage manager with the given index id. Behaviour is unspecified
 				//                          if the index id or the storage manager are incorrect.
 				// Dimension                VT_ULONG  Dimensionality of the data that will be inserted.
@@ -120,7 +120,7 @@ namespace SpatialIndex
 				// for Points and Rectangles', Section 4.1]
 
 			double m_splitDistributionFactor;
-				// The R*-Tree 'm' constant, for calculating spliting distributions.
+				// The R*-Tree 'm' constant, for calculating splitting distributions.
 				// [Beckmann, Kriegel, Schneider, Seeger 'The R*-tree: An efficient and Robust Access Method
 				// for Points and Rectangles', Section 4.2]
 

--- a/src/spatialindex/MovingRegion.cc
+++ b/src/spatialindex/MovingRegion.cc
@@ -334,7 +334,7 @@ bool MovingRegion::intersectsRegionInTime(const MovingRegion& r, IInterval& ivOu
 //
 // there are various cases here:
 // 1. one region contains the other.
-// 2. one boundary of one region is always contained indide the other region, while the other
+// 2. one boundary of one region is always contained inside the other region, while the other
 //    boundary is not (so no boundaries will ever intersect).
 // 3. either the upper or lower boundary of one region intersects a boundary of the other.
 bool MovingRegion::intersectsRegionInTime(const IInterval& ivPeriod, const MovingRegion& r, IInterval& ivOut) const
@@ -379,7 +379,7 @@ bool MovingRegion::intersectsRegionInTime(const IInterval& ivPeriod, const Movin
 		tmin >= m_startTime && tmax <= m_endTime &&
 		tmin >= r.m_startTime && tmax <= r.m_endTime);
 
-		// completely above or bellow in i-th dimension
+		// completely above or below in i-th dimension
 		if (
 			(r.getExtrapolatedLow(cDim, tmin) > getExtrapolatedHigh(cDim, tmin) &&
 			r.getExtrapolatedLow(cDim, tmax) >= getExtrapolatedHigh(cDim, tmax)) ||
@@ -706,7 +706,7 @@ bool MovingRegion::intersectsPointInTime(const IInterval& ivPeriod, const Moving
 			tmin >= m_startTime && tmax <= m_endTime &&
 			tmin >= p.m_startTime && tmax <= p.m_endTime);
 
-		// completely above or bellow in i-th dimension
+		// completely above or below in i-th dimension
 		if ((p.getProjectedCoord(cDim, tmin) > getExtrapolatedHigh(cDim, tmin) &&
 			p.getProjectedCoord(cDim, tmax) >= getExtrapolatedHigh(cDim, tmax)) ||
 			(p.getProjectedCoord(cDim, tmin) < getExtrapolatedLow(cDim, tmin) &&

--- a/src/spatialindex/Region.cc
+++ b/src/spatialindex/Region.cc
@@ -461,7 +461,7 @@ double Region::getIntersectingArea(const Region& r) const
 }
 
 /*
- * Returns the margin of a region. It is calcuated as the sum of  2^(d-1) * width, in each dimension.
+ * Returns the margin of a region. It is calculated as the sum of  2^(d-1) * width, in each dimension.
  * It is actually the sum of all edges, no matter what the dimensionality is.
 */
 double Region::getMargin() const

--- a/src/spatialindex/TimeRegion.cc
+++ b/src/spatialindex/TimeRegion.cc
@@ -138,7 +138,7 @@ bool TimeRegion::intersectsRegionInTime(const TimeRegion& r) const
 	// the first check is needed for the following case:
 	// m_endTime == m_startTime == r.m_startTime.
 	// For open ended intervals this should be considered as an intersection
-	// (takes care of degenarate intervals)
+	// (takes care of degenerate intervals)
 	//if (m_startTime != r.m_startTime &&
 	//	(m_startTime >= r.m_endTime || m_endTime <= r.m_startTime))
 	if (! intersectsInterval(r)) return false;
@@ -356,7 +356,7 @@ bool TimeRegion::intersectsInterval(Tools::IntervalType, const double start, con
 {
 	//if (m_startTime != start &&
 	//		(m_startTime >= end || m_endTime <= start)) return false;
-	// this will not work for degenarate intervals.
+	// this will not work for degenerate intervals.
 	if (m_startTime >= end || m_endTime <= start) return false;
 
 	return true;

--- a/src/tools/Tools.cc
+++ b/src/tools/Tools.cc
@@ -1094,7 +1094,7 @@ Tools::TemporaryFile::TemporaryFile()
 #   endif
   std::string tempDir ((val != nullptr) ? val : default_tmp);
 
-  // now contruct the temporary filename
+  // now construct the temporary filename
   std::string tempName = tempDir + "/spatialindex-XXXXXX";
   char* tmpName = strdup(tempName.c_str());
   if (!tmpName || mkstemp(tmpName) == -1)

--- a/src/tprtree/Node.cc
+++ b/src/tprtree/Node.cc
@@ -548,7 +548,7 @@ bool Node::insertData(uint32_t dataLength, uint8_t* pData, MovingRegion& mbr, id
 
 		m_pTree->writeNode(this);
 
-		// Divertion from R*-Tree algorithm here. First adjust
+		// Diversion from R*-Tree algorithm here. First adjust
 		// the path to the root, then start reinserts, to avoid complicated handling
 		// of changes to the same node from multiple insertions.
 		id_type cParent = pathBuffer.top(); pathBuffer.pop();
@@ -720,7 +720,7 @@ void Node::rtreeSplit(uint32_t dataLength, uint8_t* pData, Region& mbr, id_type 
 	{
 		if (minimumLoad - group1.size() == cRemaining)
 		{
-			// all remaining entries must be assigned to group1 to comply with minimun load requirement.
+			// all remaining entries must be assigned to group1 to comply with minimum load requirement.
 			for (cChild = 0; cChild < m_capacity + 1; ++cChild)
 			{
 				if (mask[cChild] == 0)
@@ -733,7 +733,7 @@ void Node::rtreeSplit(uint32_t dataLength, uint8_t* pData, Region& mbr, id_type 
 		}
 		else if (minimumLoad - group2.size() == cRemaining)
 		{
-			// all remaining entries must be assigned to group2 to comply with minimun load requirement.
+			// all remaining entries must be assigned to group2 to comply with minimum load requirement.
 			for (cChild = 0; cChild < m_capacity + 1; ++cChild)
 			{
 				if (mask[cChild] == 0)

--- a/src/tprtree/TPRTree.cc
+++ b/src/tprtree/TPRTree.cc
@@ -322,7 +322,7 @@ bool SpatialIndex::TPRTree::TPRTree::deleteData(const IShape& shape, id_type id)
 
 void SpatialIndex::TPRTree::TPRTree::internalNodesQuery(const IShape& /* query */, IVisitor& /* v */)
 {
-	throw Tools::IllegalStateException("internalNodesQuery: not impelmented yet.");
+	throw Tools::IllegalStateException("internalNodesQuery: not implemented yet.");
 }
 
 void SpatialIndex::TPRTree::TPRTree::containsWhatQuery(const IShape& query, IVisitor& v)
@@ -346,7 +346,7 @@ void SpatialIndex::TPRTree::TPRTree::pointLocationQuery(const Point& query, IVis
 
 void SpatialIndex::TPRTree::TPRTree::nearestNeighborQuery(uint32_t, const IShape&, IVisitor&, INearestNeighborComparator&)
 {
-	throw Tools::IllegalStateException("nearestNeighborQuery: not impelmented yet.");
+	throw Tools::IllegalStateException("nearestNeighborQuery: not implemented yet.");
 }
 
 void SpatialIndex::TPRTree::TPRTree::nearestNeighborQuery(uint32_t k, const IShape& query, IVisitor& v)
@@ -358,7 +358,7 @@ void SpatialIndex::TPRTree::TPRTree::nearestNeighborQuery(uint32_t k, const ISha
 
 void SpatialIndex::TPRTree::TPRTree::selfJoinQuery(const IShape&, IVisitor&)
 {
-	throw Tools::IllegalStateException("selfJoinQuery: not impelmented yet.");
+	throw Tools::IllegalStateException("selfJoinQuery: not implemented yet.");
 }
 
 void SpatialIndex::TPRTree::TPRTree::queryStrategy(IQueryStrategy& qs)

--- a/src/tprtree/TPRTree.h
+++ b/src/tprtree/TPRTree.h
@@ -44,7 +44,7 @@ namespace SpatialIndex
 			TPRTree(IStorageManager&, Tools::PropertySet&);
 				// String                   Value     Description
 				// ----------------------------------------------
-				// IndexIndentifier         VT_LONG   If specified an existing index will be openened from the supplied
+				// IndexIndentifier         VT_LONG   If specified an existing index will be opened from the supplied
 				//                          storage manager with the given index id. Behaviour is unspecified
 				//                          if the index id or the storage manager are incorrect.
 				// Dimension                VT_ULONG  Dimensionality of the data that will be inserted.
@@ -117,7 +117,7 @@ namespace SpatialIndex
 				// for Points and Rectangles', Section 4.1]
 
 			double m_splitDistributionFactor;
-				// The R*-Tree 'm' constant, for calculating spliting distributions.
+				// The R*-Tree 'm' constant, for calculating splitting distributions.
 				// [Beckmann, Kriegel, Schneider, Seeger 'The R*-tree: An efficient and Robust Access Method
 				// for Points and Rectangles', Section 4.2]
 

--- a/test/gtest/gtest-1.14.0/include/gtest/gtest-printers.h
+++ b/test/gtest/gtest-1.14.0/include/gtest/gtest-printers.h
@@ -1106,7 +1106,7 @@ void UniversalTersePrint(const T& value, ::std::ostream* os) {
 // NUL-terminated string.
 template <typename T>
 void UniversalPrint(const T& value, ::std::ostream* os) {
-  // A workarond for the bug in VC++ 7.1 that prevents us from instantiating
+  // A workaround for the bug in VC++ 7.1 that prevents us from instantiating
   // UniversalPrinter with T directly.
   typedef T T1;
   UniversalPrinter<T1>::Print(value, os);

--- a/test/mvrtree/MVRTreeLoad.cc
+++ b/test/mvrtree/MVRTreeLoad.cc
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
 					// case you should store the data externally. The index will provide the data IDs of
 					// the answers to any query, which can be used to access the actual data from the external
 					// storage (e.g. a hash table or a database table, etc.).
-					// Storing the data in the index is convinient and in case a clustered storage manager is
+					// Storing the data in the index is convenient and in case a clustered storage manager is
 					// provided (one that stores any node in consecutive pages) performance will improve substantially,
 					// since disk accesses will be mostly sequential. On the other hand, the index will need to
 					// manipulate the data, resulting in larger overhead. If you use a main memory storage manager,
@@ -189,7 +189,7 @@ int main(int argc, char** argv)
 
 		bool ret = tree->isIndexValid();
 		if (ret == false) cerr << "ERROR: Structure is invalid!" << endl;
-		else cerr << "The stucture seems O.K." << endl;
+		else cerr << "The structure seems O.K." << endl;
 
 		delete tree;
 		//delete file;

--- a/test/mvrtree/MVRTreeQuery.cc
+++ b/test/mvrtree/MVRTreeQuery.cc
@@ -254,7 +254,7 @@ int main(int argc, char** argv)
 		delete file;
 		delete diskfile;
 			// delete the buffer first, then the storage manager
-			// (otherwise the the buffer will fail writting the dirty entries).
+			// (otherwise the the buffer will fail writing the dirty entries).
 	}
 	catch (Tools::Exception& e)
 	{

--- a/test/rtree/RTreeBulkLoad.cc
+++ b/test/rtree/RTreeBulkLoad.cc
@@ -148,7 +148,7 @@ int main(int argc, char** argv)
 
 		bool ret = tree->isIndexValid();
 		if (ret == false) std::cerr << "ERROR: Structure is invalid!" << std::endl;
-		else std::cerr << "The stucture seems O.K." << std::endl;
+		else std::cerr << "The structure seems O.K." << std::endl;
 
 		delete tree;
 		delete file;

--- a/test/rtree/RTreeLoad.cc
+++ b/test/rtree/RTreeLoad.cc
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
 					// case you should store the data externally. The index will provide the data IDs of
 					// the answers to any query, which can be used to access the actual data from the external
 					// storage (e.g. a hash table or a database table, etc.).
-					// Storing the data in the index is convinient and in case a clustered storage manager is
+					// Storing the data in the index is convenient and in case a clustered storage manager is
 					// provided (one that stores any node in consecutive pages) performance will improve substantially,
 					// since disk accesses will be mostly sequential. On the other hand, the index will need to
 					// manipulate the data, resulting in larger overhead. If you use a main memory storage manager,
@@ -195,7 +195,7 @@ int main(int argc, char** argv)
 
 		bool ret = tree->isIndexValid();
 		if (ret == false) std::cerr << "ERROR: Structure is invalid!" << std::endl;
-		else std::cerr << "The stucture seems O.K." << std::endl;
+		else std::cerr << "The structure seems O.K." << std::endl;
 
 		delete tree;
 		delete file;

--- a/test/rtree/RTreeQuery.cc
+++ b/test/rtree/RTreeQuery.cc
@@ -258,7 +258,7 @@ int main(int argc, char** argv)
 		delete file;
 		delete diskfile;
 			// delete the buffer first, then the storage manager
-			// (otherwise the the buffer will fail writting the dirty entries).
+			// (otherwise the the buffer will fail writing the dirty entries).
 	}
 	catch (Tools::Exception& e)
 	{

--- a/test/tprtree/TPRTreeLoad.cc
+++ b/test/tprtree/TPRTreeLoad.cc
@@ -117,7 +117,7 @@ int main(int argc, char** argv)
 					// case you should store the data externally. The index will provide the data IDs of
 					// the answers to any query, which can be used to access the actual data from the external
 					// storage (e.g. a hash table or a database table, etc.).
-					// Storing the data in the index is convinient and in case a clustered storage manager is
+					// Storing the data in the index is convenient and in case a clustered storage manager is
 					// provided (one that stores any node in consecutive pages) performance will improve substantially,
 					// since disk accesses will be mostly sequential. On the other hand, the index will need to
 					// manipulate the data, resulting in larger overhead. If you use a main memory storage manager,
@@ -178,7 +178,7 @@ int main(int argc, char** argv)
 
 		bool ret = tree->isIndexValid();
 		if (ret == false) cerr << "ERROR: Structure is invalid!" << endl;
-		else cerr << "The stucture seems O.K." << endl;
+		else cerr << "The structure seems O.K." << endl;
 
 		delete tree;
 		delete file;

--- a/test/tprtree/TPRTreeQuery.cc
+++ b/test/tprtree/TPRTreeQuery.cc
@@ -211,7 +211,7 @@ int main(int argc, char** argv)
 					// case you should store the data externally. The index will provide the data IDs of
 					// the answers to any query, which can be used to access the actual data from the external
 					// storage (e.g. a hash table or a database table, etc.).
-					// Storing the data in the index is convinient and in case a clustered storage manager is
+					// Storing the data in the index is convenient and in case a clustered storage manager is
 					// provided (one that stores any node in consecutive pages) performance will improve substantially,
 					// since disk accesses will be mostly sequential. On the other hand, the index will need to
 					// manipulate the data, resulting in larger overhead. If you use a main memory storage manager,
@@ -284,7 +284,7 @@ int main(int argc, char** argv)
 		delete file;
 		delete diskfile;
 			// delete the buffer first, then the storage manager
-			// (otherwise the the buffer will fail writting the dirty entries).
+			// (otherwise the the buffer will fail writing the dirty entries).
 	}
 	catch (Tools::Exception& e)
 	{


### PR DESCRIPTION
This PR adds a configuration for [codespell](https://github.com/codespell-project/codespell), and fixes a handful of typos.