### PR TITLE
Fix a memory leak introduced in the previous commit.

### DIFF
--- a/src/rtree/BulkLoader.cc
+++ b/src/rtree/BulkLoader.cc
@@ -91,15 +91,7 @@ void ExternalSorter::Record::loadFromFile(Tools::TemporaryFile& f)
 	m_id = static_cast<id_type>(f.readUInt64());
 	uint32_t dim = f.readUInt32();
 	m_s = f.readUInt32();
-
-	if (dim != m_r.m_dimension)
-	{
-		delete[] m_r.m_pLow;
-		delete[] m_r.m_pHigh;
-		m_r.m_dimension = dim;
-		m_r.m_pLow = new double[dim];
-		m_r.m_pHigh = new double[dim];
-	}
+	m_r.makeDimension(dim);
 
 	for (uint32_t i = 0; i < m_r.m_dimension; ++i)
 	{


### PR DESCRIPTION
This fixes some memory leaks which my previous commit introduced.

ASAN is still showing one leak when running the tests:

```
Direct leak of 120 byte(s) in 1 object(s) allocated from:
    #0 0x7f8b634f9e68 in operator new(unsigned long) (/usr/lib/gcc/x86_64-pc-linux-gnu/14/libasan.so.8+0xf9e68)
    #1 0x7f8b631df4df in SpatialIndex::RTree::ExternalSorter::getNextRecord() /home/freddie/Programming/libspatialindex/src/rtree/BulkLoader.cc:297
    #2 0x7f8b631e0ad2 in SpatialIndex::RTree::BulkLoader::createLevel(SpatialIndex::RTree::RTree*, std::shared_ptr<SpatialIndex::RTree::ExternalSorter>, unsigned int, unsigned int, unsigned int, unsigned int, std::shared_ptr<SpatialIndex::RTree::ExternalSorter>, unsigned int, unsigned int) /home/freddie/Programming/libspatialindex/src/rtree/BulkLoader.cc:422
    #3 0x7f8b631dfee4 in SpatialIndex::RTree::BulkLoader::bulkLoadUsingSTR(SpatialIndex::RTree::RTree*, SpatialIndex::IDataStream&, unsigned int, unsigned int, unsigned int, unsigned int) /home/freddie/Programming/libspatialindex/src/rtree/BulkLoader.cc:354
    #4 0x7f8b6321d4e0 in SpatialIndex::RTree::createAndBulkLoadNewRTree(SpatialIndex::RTree::BulkLoadMethod, SpatialIndex::IDataStream&, SpatialIndex::IStorageManager&, double, unsigned int, unsigned int, unsigned int, SpatialIndex::RTree::RTreeVariant, long&) /home/freddie/Programming/libspatialindex/src/rtree/RTree.cc:211
    #5 0x557283599bc6 in main /home/freddie/Programming/libspatialindex/test/rtree/RTreeBulkLoad.cc:142
    #6 0x7f8b62a5142d  (/usr/lib64/libc.so.6+0x2642d)

SUMMARY: AddressSanitizer: 120 byte(s) leaked in 1 allocation(s).
```
but I believe this to be pre-existing.