### PR TITLE
Reduce overhead in kNN queries

### DIFF
--- a/src/rtree/RTree.cc
+++ b/src/rtree/RTree.cc
@@ -611,7 +611,7 @@ void SpatialIndex::RTree::RTree::nearestNeighborQuery(uint32_t k, const IShape& 
 					Data* e = new Data(n->m_pDataLength[cChild], n->m_pData[cChild], *(n->m_ptrMBR[cChild]), n->m_pIdentifier[cChild]);
 					// we need to compare the query with the actual data entry here, so we call the
 					// appropriate getMinimumDistance method of NearestNeighborComparator.
-					queue.push(NNEntry(n->m_pIdentifier[cChild], e, nnc.getMinimumDistance(query, *e)));
+					queue.push(NNEntry(n->m_pIdentifier[cChild], e, nnc.getMinimumDistance(query, e->m_region)));
 				}
 				else
 				{

--- a/src/rtree/RTree.h
+++ b/src/rtree/RTree.h
@@ -150,10 +150,10 @@ namespace SpatialIndex
 			{
 			public:
 				id_type m_id;
-				IEntry* m_pEntry;
+				Data* m_pEntry;
 				double m_minDist;
 
-				NNEntry(id_type id, IEntry* e, double f) : m_id(id), m_pEntry(e), m_minDist(f) {}
+				NNEntry(id_type id, Data* e, double f) : m_id(id), m_pEntry(e), m_minDist(f) {}
 				~NNEntry() = default;
 
 			}; // NNEntry


### PR DESCRIPTION
Here we take advantage of the fact that we know some data types.  In particular, we know what `getShape` of `Data` will do (create a new instance of its `Region`).  Thus, we can just pass this region in directly.  This saves a new/delete pair.  The improvement from this is around ~5%.