### PR TITLE
Add an alternative bulk-insert API

### DIFF
--- a/include/spatialindex/capi/Index.h
+++ b/include/spatialindex/capi/Index.h
@@ -30,12 +30,14 @@
 
 
 #include "sidx_export.h"
+#include <memory>
 
 class SIDX_DLL Index
 {
 
 public:
     Index(const Tools::PropertySet& poProperties);
+    Index(const Tools::PropertySet& poProperties, std::unique_ptr<SpatialIndex::IDataStream> stream);
     Index(const Tools::PropertySet& poProperties, int (*readNext)(SpatialIndex::id_type *id, double **pMin, double **pMax, uint32_t *nDimension, const uint8_t **pData, size_t* nDataLength));
     ~Index();
 

--- a/include/spatialindex/capi/sidx_api.h
+++ b/include/spatialindex/capi/sidx_api.h
@@ -43,6 +43,8 @@ SIDX_DLL IndexH Index_CreateWithStream( IndexPropertyH properties,
 										int (*readNext)(int64_t *id, double **pMin, double **pMax, uint32_t *nDimension, const uint8_t **pData, size_t *nDataLength)
 									   );
 
+SIDX_DLL IndexH Index_CreateWithArray(IndexPropertyH properties, uint64_t n, uint32_t dimension, uint64_t i_stri, uint64_t d_i_stri, uint64_t d_j_stri, int64_t *ids, double *mins, double *maxs);
+
 SIDX_DLL void Index_Destroy(IndexH index);
 SIDX_DLL IndexPropertyH Index_GetProperties(IndexH index);
 

--- a/src/capi/Index.cc
+++ b/src/capi/Index.cc
@@ -119,6 +119,11 @@ Index::Index(	const Tools::PropertySet& poProperties,
 								uint32_t *nDimension,
 								const uint8_t **pData,
 								size_t *nDataLength))
+: Index(poProperties, std::unique_ptr<DataStream>(new DataStream(readNext)))
+{}
+
+Index::Index(const Tools::PropertySet& poProperties,
+             std::unique_ptr<SpatialIndex::IDataStream> ds)
 : m_properties(poProperties)
 {
 	using namespace SpatialIndex;
@@ -128,7 +133,6 @@ Index::Index(	const Tools::PropertySet& poProperties,
 	m_storage = CreateStorage();
 	m_buffer = CreateIndexBuffer(*m_storage);
 
-	DataStream ds(readNext);
 	SpatialIndex::id_type m_IdxIdentifier;
 
 	// For memory storage ensure we do not write any files to disk during
@@ -156,7 +160,7 @@ Index::Index(	const Tools::PropertySet& poProperties,
 	}
 
 	m_rtree = RTree::createAndBulkLoadNewRTree(	  SpatialIndex::RTree::BLM_STR,
-												  ds,
+												  *ds,
 												  *m_buffer,
 												  m_properties,
 												  m_IdxIdentifier);

--- a/test/gtest/sidx_api_test.h
+++ b/test/gtest/sidx_api_test.h
@@ -140,4 +140,37 @@ TEST_F(SidxApiRTreeTest, contains_count) {
     EXPECT_EQ(1, nResults);
 }
 
+
+class SidxApiBulkRTreeTest : public testing::Test {
+  protected:
+  void SetUp() override {
+    IndexPropertyH props = IndexProperty_Create();
+    IndexProperty_SetDimension(props, 3);
+    IndexProperty_SetIndexType(props, RT_RTree);
+    IndexProperty_SetIndexStorage(props, RT_Memory);
+    struct { int64_t i; double p[3]; } ents[] = {
+      { 10, {-1, -1, -1}},
+      { 11, {5, 5, 5}}
+    };
+    uint64_t i_stri = &ents[1].i - &ents[0].i;
+    uint64_t d_i_stri = &ents[1].p[0] - &ents[0].p[0];
+    uint64_t d_j_stri = &ents[0].p[1] - &ents[0].p[0];
+    idx = Index_CreateWithArray(props, 2, 3, i_stri, d_i_stri, d_j_stri,
+                                &ents[0].i, ents[0].p, ents[0].p);
+    IndexProperty_Destroy(props);
+  }
+
+  void TearDown() override {
+    Index_Destroy(idx);
+  }
+
+  IndexH idx;
+};
+
+TEST_F(SidxApiBulkRTreeTest, bulk_intersects_count) {
+  uint64_t nResults = 42;
+  double min[] = {-100, -100, -100}, max[] = {100, 100, 100};
+  Index_Intersects_count(idx, min, max, 3, &nResults);
+  EXPECT_EQ(2, nResults);
+}
 #endif // SIDX_API_TEST_H


### PR DESCRIPTION
This is intended to gather feedback.  I've mocked up a bulk insert API which takes a set of array pointers as opposed to a function pointer.  This requires some very minor refactoring but nothing too major.  Feedback on the overall approach would be appreciated.  I've tried to make the API reasonably flexible by including strides which should allow most reasonable data structures (AoS or SoA) to be directly ingested.

Assuming everything checks out I'll wire everything up for Python RTree.