### PR TITLE
Support testing with a system/external copy of GTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ message(STATUS
 include(CTest)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_TESTING "Enables integrated test suites" OFF)
+option(SYSTEM_GTEST "Use an external/system copy of GoogleTest" OFF)
 
 if(DEFINED SIDX_BUILD_TESTS)
   message(DEPRECATION "SIDX_BUILD_TESTS has been replaced with BUILD_TESTING")

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -1,7 +1,11 @@
 set(GOOGLETEST_VERSION "1.14.0")
 
-add_subdirectory(gtest-1.14.0)
-include_directories(./gtest-1.14.0/include)
+if (SYSTEM_GTEST)
+    find_package(GTest REQUIRED)
+else()
+    add_subdirectory(gtest-1.14.0)
+    include_directories(./gtest-1.14.0/include)
+endif()
 
 set(SOURCES
     test.h


### PR DESCRIPTION
Adds a `SYSTEM_GTEST` CMake option, which remains disabled by default. This is useful for Linux distribution packagers who would prefer not to use the bundled copy.