### PR TITLE
Delete data in NNEntry on destruction

### DIFF
--- a/src/rtree/RTree.cc
+++ b/src/rtree/RTree.cc
@@ -590,13 +590,13 @@ double SpatialIndex::RTree::RTree::nearestNeighborQuery(uint32_t k, const IShape
             ++(m_stats.m_u64QueryResults);
             ++count;
             knearest = pFirst.m_minDist;
-            queue.pop();
+            queue.pop();  // Done with pFirst.
         }
         else
         {
             // n is a leaf or an index.
             NodePtr n = readNode(pFirst.m_id);
-            queue.pop();
+            queue.pop();  // Done with pFirst.
 
             v.visitNode(*n);
 

--- a/src/rtree/RTree.cc
+++ b/src/rtree/RTree.cc
@@ -604,7 +604,7 @@ double SpatialIndex::RTree::RTree::nearestNeighborQuery(uint32_t k, const IShape
             {
                 if (n->m_level == 0)
                 {
-                    Data *e(new Data(n->m_pDataLength[cChild], n->m_pData[cChild], *(n->m_ptrMBR[cChild]), n->m_pIdentifier[cChild]));
+                    Data* e(new Data(n->m_pDataLength[cChild], n->m_pData[cChild], *(n->m_ptrMBR[cChild]), n->m_pIdentifier[cChild]));
                     // we need to compare the query with the actual data entry here, so we call the
                     // appropriate getMinimumDistance method of NearestNeighborComparator.
                     queue.push(NNEntry(n->m_pIdentifier[cChild], e, nnc.getMinimumDistance(query, e->m_region)));

--- a/src/rtree/RTree.cc
+++ b/src/rtree/RTree.cc
@@ -562,16 +562,6 @@ void SpatialIndex::RTree::RTree::pointLocationQuery(const Point& query, IVisitor
 	rangeQuery(IntersectionQuery, r, v);
 }
 
-template <class T, class S, class C>
-    S& Container(std::priority_queue<T, S, C>& q) {
-        struct HackedQueue : private std::priority_queue<T, S, C> {
-            static S& Container(std::priority_queue<T, S, C>& q) {
-                return q.*&HackedQueue::c;
-            }
-        };
-    return HackedQueue::Container(q);
-}
-
 double SpatialIndex::RTree::RTree::nearestNeighborQuery(uint32_t k, const IShape& query, IVisitor& v, INearestNeighborComparator& nnc, double max_dist)
 {
     if (query.getDimension() != m_dimension) throw Tools::IllegalArgumentException("nearestNeighborQuery: Shape has the wrong number of dimensions.");
@@ -579,18 +569,14 @@ double SpatialIndex::RTree::RTree::nearestNeighborQuery(uint32_t k, const IShape
     auto ascending = [](const NNEntry& lhs, const NNEntry& rhs) { return lhs.m_minDist > rhs.m_minDist;  };
     std::priority_queue<NNEntry, std::vector<NNEntry>, decltype(ascending)> queue(ascending);
 
-    // Extract the container from the queue
-    std::vector<NNEntry>& queue_c = Container(queue);
-    queue_c.reserve(64);
-
-    queue.push(NNEntry(m_rootID, nullptr, 0.0));
+    queue.push(NNEntry(m_rootID));
 
     uint32_t count = 0;
     double knearest = 0.0;
 
     while (! queue.empty())
     {
-        NNEntry pFirst = queue.top();
+        const NNEntry& pFirst = queue.top();
 
         if (max_dist && pFirst.m_minDist > max_dist) break;
 
@@ -598,19 +584,27 @@ double SpatialIndex::RTree::RTree::nearestNeighborQuery(uint32_t k, const IShape
         // (neighbors can be more than k, if many happen to have the same greatest distance).
         if (count >= k && pFirst.m_minDist > knearest) break;
 
-        queue.pop();
-
-        if (pFirst.m_pEntry == nullptr)
+        if (pFirst.m_pEntry)
+        {
+            v.visitData(*(static_cast<IData*>(pFirst.m_pEntry)));
+            ++(m_stats.m_u64QueryResults);
+            ++count;
+            knearest = pFirst.m_minDist;
+            queue.pop();
+        }
+        else
         {
             // n is a leaf or an index.
             NodePtr n = readNode(pFirst.m_id);
+            queue.pop();
+
             v.visitNode(*n);
 
             for (uint32_t cChild = 0; cChild < n->m_children; ++cChild)
             {
                 if (n->m_level == 0)
                 {
-                    Data* e = new Data(n->m_pDataLength[cChild], n->m_pData[cChild], *(n->m_ptrMBR[cChild]), n->m_pIdentifier[cChild]);
+                    Data *e(new Data(n->m_pDataLength[cChild], n->m_pData[cChild], *(n->m_ptrMBR[cChild]), n->m_pIdentifier[cChild]));
                     // we need to compare the query with the actual data entry here, so we call the
                     // appropriate getMinimumDistance method of NearestNeighborComparator.
                     queue.push(NNEntry(n->m_pIdentifier[cChild], e, nnc.getMinimumDistance(query, e->m_region)));
@@ -621,19 +615,7 @@ double SpatialIndex::RTree::RTree::nearestNeighborQuery(uint32_t k, const IShape
                 }
             }
         }
-        else
-        {
-            v.visitData(*(static_cast<IData*>(pFirst.m_pEntry)));
-            ++(m_stats.m_u64QueryResults);
-            ++count;
-            knearest = pFirst.m_minDist;
-            delete pFirst.m_pEntry;
-        }
     }
-
-    for (auto& e : queue_c)
-        if (e.m_pEntry)
-            delete e.m_pEntry;
 
     return knearest;
 }

--- a/src/rtree/RTree.cc
+++ b/src/rtree/RTree.cc
@@ -604,7 +604,7 @@ double SpatialIndex::RTree::RTree::nearestNeighborQuery(uint32_t k, const IShape
             {
                 if (n->m_level == 0)
                 {
-                    Data* e(new Data(n->m_pDataLength[cChild], n->m_pData[cChild], *(n->m_ptrMBR[cChild]), n->m_pIdentifier[cChild]));
+                    Data* e = new Data(n->m_pDataLength[cChild], n->m_pData[cChild], *(n->m_ptrMBR[cChild]), n->m_pIdentifier[cChild]);
                     // we need to compare the query with the actual data entry here, so we call the
                     // appropriate getMinimumDistance method of NearestNeighborComparator.
                     queue.push(NNEntry(n->m_pIdentifier[cChild], e, nnc.getMinimumDistance(query, e->m_region)));

--- a/src/rtree/RTree.h
+++ b/src/rtree/RTree.h
@@ -153,7 +153,9 @@ namespace SpatialIndex
 				Data* m_pEntry;
 				double m_minDist;
 
-				NNEntry(id_type id, Data* e, double f) : m_id(id), m_pEntry(e), m_minDist(f) {}
+				NNEntry(id_type id) : m_id(id), m_pEntry(nullptr), m_minDist(0) {}
+				NNEntry(id_type id, Data *e, double f) :
+                    m_id(id), m_pEntry(e), m_minDist(f) {}
 				~NNEntry() = default;
 
 			}; // NNEntry

--- a/src/rtree/RTree.h
+++ b/src/rtree/RTree.h
@@ -156,8 +156,24 @@ namespace SpatialIndex
 				NNEntry(id_type id) : m_id(id), m_pEntry(nullptr), m_minDist(0) {}
 				NNEntry(id_type id, Data *e, double f) :
                     m_id(id), m_pEntry(e), m_minDist(f) {}
-				~NNEntry() = default;
+                NNEntry(NNEntry&& other)
+                {
+                    m_id = other.m_id;
+                    m_pEntry = other.m_pEntry;
+                    m_minDist = other.m_minDist;
+                    other.m_pEntry = nullptr;
+                }
+                NNEntry& operator=(NNEntry&& other)
+                {
+                    m_id = other.m_id;
+                    m_pEntry = other.m_pEntry;
+                    m_minDist = other.m_minDist;
+                    other.m_pEntry = nullptr;
+                    return *this;
 
+                }
+				~NNEntry()
+                { delete m_pEntry; }
 			}; // NNEntry
 
 			class NNComparator : public INearestNeighborComparator


### PR DESCRIPTION
This just provides another way to tear down the priority queue other than in #265. It contains the pointer cleanup in `NNEntry` rather than have it bleed into `nearestNeighborQuery`. Not as beautiful as it might be because you can't stick non-copyable things in a `std::priority_queue`. :(

Do with this what you will.