### PR TITLE
Remove redundant loop for clearing std::stack in destructor

### DIFF
--- a/src/mvrtree/PointerPoolNode.h
+++ b/src/mvrtree/PointerPoolNode.h
@@ -41,11 +41,6 @@ namespace Tools
 		~PointerPool()
 		{
 			assert(m_pool.size() <= m_capacity);
-
-			while (! m_pool.empty())
-			{
-				SpatialIndex::MVRTree::Node* x = m_pool.top(); m_pool.pop();
-			}
 		}
 
 		PoolPointer<SpatialIndex::MVRTree::Node> acquire()


### PR DESCRIPTION
This will happen anyway, and we aren't doing anything with the objects
 on the stack (eg deleting them) to make the loop meaningful