### PR TITLE
Remove unnecessary assertion

### DIFF
--- a/src/mvrtree/PointerPoolNode.h
+++ b/src/mvrtree/PointerPoolNode.h
@@ -86,7 +86,6 @@ namespace Tools
 		uint32_t getCapacity() const { return m_capacity; }
 		void setCapacity(uint32_t c)
 		{
-			assert (c >= 0);
 			m_capacity = c;
 		}
 


### PR DESCRIPTION
A variable of type `uint32_t` is guaranteed to be a positive number (even if some two's-complement or floating point encoded value finds its way in there somehow!), so a non-negativity assertion will never trigger. This assertion does trigger distracting warnings by some compilers.