### PR TITLE
Reject non-finite (NaN/Infinity) coordinates in RTree::insertData

### DIFF
--- a/src/rtree/RTree.cc
+++ b/src/rtree/RTree.cc
@@ -409,6 +409,20 @@ void SpatialIndex::RTree::RTree::insertData(uint32_t len, const uint8_t* pData, 
 	RegionPtr mbr = m_regionPool.acquire();
 	shape.getMBR(*mbr);
 
+	// Reject non-finite (NaN or +/-Infinity) coordinates here, at the point of insertion,
+	// rather than allowing them to silently enter the tree. A NaN or Infinite bound poisons
+	// every subsequent margin/area comparison it participates in (comparisons against NaN are
+	// always false), which can leave R*-tree's chooseSplitAxis() unable to select a split axis
+	// and crash much later, in an unrelated split, on data that looks unrelated to the bad
+	// insert. Failing fast here gives a clear, actionable error instead.
+	for (uint32_t cDim = 0; cDim < mbr->m_dimension; ++cDim)
+	{
+		if (!std::isfinite(mbr->m_pLow[cDim]) || !std::isfinite(mbr->m_pHigh[cDim]))
+			throw Tools::IllegalArgumentException(
+				"insertData: Shape region contains a NaN or Infinite coordinate."
+			);
+	}
+
 	uint8_t* buffer = nullptr;
 
 	if (len > 0)

--- a/test/gtest/RTree.cpp
+++ b/test/gtest/RTree.cpp
@@ -146,3 +146,85 @@ TEST(RTreeTest, SelfJoinQueriesMatchExhaustiveSearch) {
     sidx_test::expectSamePairs(sidx_test::selfJoinPairs(active, query), visitor.pairs);
     EXPECT_TRUE(tree->isIndexValid());
 }
+
+// Regression test for https://github.com/libspatialindex/libspatialindex/issues/107
+//
+// A NaN (or Infinite) coordinate in an inserted region used to be accepted
+// silently. Because comparisons against NaN are always false, it poisons
+// every margin/area comparison it participates in, which can leave
+// Node::rstarSplit()'s chooseSplitAxis() step unable to select a split axis
+// (splitAxis stays at its uint32_t sentinel). That sentinel is then used to
+// index Region::m_pLow/m_pHigh in RstarSplitEntry::compareHigh(), causing an
+// out-of-bounds read/segfault -- often several inserts after the actual bad
+// data, on a split that looks unrelated. insertData() now rejects non-finite
+// coordinates immediately with a clear exception instead.
+TEST(RTreeTest, InsertingNonFiniteCoordinateThrowsInsteadOfCorruptingTree) {
+    std::unique_ptr<SpatialIndex::IStorageManager> storage = sidx_test::memoryStorage();
+    SpatialIndex::id_type indexIdentifier;
+    std::unique_ptr<SpatialIndex::ISpatialIndex> tree(
+        SpatialIndex::RTree::createNewRTree(
+            *storage, 0.7, 4, 4, 2, SpatialIndex::RTree::RV_RSTAR, indexIdentifier));
+
+    double nan_low[2] = { std::numeric_limits<double>::quiet_NaN(), 1.0 };
+    double nan_high[2] = { 2.0, 2.0 };
+    SpatialIndex::Region nanRegion(nan_low, nan_high, 2);
+
+    EXPECT_THROW(
+        tree->insertData(0, nullptr, nanRegion, 1),
+        Tools::IllegalArgumentException);
+
+    double inf_low[2] = { 1.0, 1.0 };
+    double inf_high[2] = { std::numeric_limits<double>::infinity(), 2.0 };
+    SpatialIndex::Region infRegion(inf_low, inf_high, 2);
+
+    EXPECT_THROW(
+        tree->insertData(0, nullptr, infRegion, 2),
+        Tools::IllegalArgumentException);
+
+    // The tree must still be perfectly usable afterwards -- rejecting bad
+    // input should not leave any partial state behind.
+    sidx_test::Rect ok(0.0, 0.0, 1.0, 1.0);
+    sidx_test::insertRect(*tree, 3, ok);
+    EXPECT_TRUE(tree->isIndexValid());
+}
+
+// End-to-end reproduction of the exact crash reported in issue #107: a single
+// NaN coordinate mixed in among otherwise normal rectangles, small node
+// capacity to force an R*-tree split soon after. Before the fix this
+// segfaulted inside RstarSplitEntry::compareHigh() on the split triggered by
+// a later, unrelated insert; the bad insert itself should now be the one
+// that fails, and cleanly.
+TEST(RTreeTest, PoisonedInsertAmongNormalDataIsRejectedBeforeAnySplit) {
+    std::unique_ptr<SpatialIndex::IStorageManager> storage = sidx_test::memoryStorage();
+    SpatialIndex::id_type indexIdentifier;
+    std::unique_ptr<SpatialIndex::ISpatialIndex> tree(
+        SpatialIndex::RTree::createNewRTree(
+            *storage, 0.7, 4, 4, 2, SpatialIndex::RTree::RV_RSTAR, indexIdentifier));
+
+    double coords[15][4] = {
+        {99.72, 93.26, 100.45, 98.25}, {23.61, 39.66, 25.61, 43.04},
+        {93.55, 84.63, 95.19, 87.30},  {44.35, 22.96, 47.06, 27.54},
+        {45.72, 43.07, 50.42, 46.98},
+        // poisoned entry: NaN x-coordinate, as if from a failed upstream parse.
+        {std::numeric_limits<double>::quiet_NaN(), 80.28, std::numeric_limits<double>::quiet_NaN(), 82.91},
+        {86.50, 82.91, 90.67, 84.35},  {5.92, 67.05, 8.93, 70.44},
+        {41.18, 19.76, 42.70, 20.55},  {78.33, 41.25, 78.60, 44.41},
+        {66.06, 29.85, 68.35, 31.04},  {7.34, 46.92, 7.91, 51.45},
+        {11.95, 52.48, 12.46, 57.07},  {91.04, 29.89, 94.01, 32.77},
+        {61.39, 95.65, 62.77, 96.89},
+    };
+
+    for (SpatialIndex::id_type i = 0; i < 15; ++i) {
+        double plow[2] = { coords[i][0], coords[i][1] };
+        double phigh[2] = { coords[i][2], coords[i][3] };
+        SpatialIndex::Region r(plow, phigh, 2);
+
+        if (i == 5) {
+            EXPECT_THROW(tree->insertData(0, nullptr, r, i), Tools::IllegalArgumentException);
+        } else {
+            EXPECT_NO_THROW(tree->insertData(0, nullptr, r, i));
+        }
+    }
+
+    EXPECT_TRUE(tree->isIndexValid());
+}


### PR DESCRIPTION
## Summary
- Fixes #107: a NaN or Infinite coordinate in an inserted region's MBR was silently accepted into the tree. Since any comparison against NaN is `false`, it poisons every margin comparison in `Node::rstarSplit()`'s chooseSplitAxis() step, leaving `splitAxis` at its `uint32_t` sentinel (`UINT32_MAX`). That sentinel is later used to index `Region::m_pLow`/`m_pHigh` in `RstarSplitEntry::compareHigh()`/`compareLow()`, causing an out-of-bounds read and segfault — often several inserts after the poisoned one, on an unrelated split, which is why the original report was hard to pin down from a backtrace alone.
- `RTree::insertData()` now validates that all MBR coordinates are finite before the shape is allowed anywhere near the tree structure, throwing `Tools::IllegalArgumentException` with a clear message, following the same validation pattern/exception type already used for the dimension-count check right above it.

## Test plan
- [x] Added `RTreeTest.InsertingNonFiniteCoordinateThrowsInsteadOfCorruptingTree`: direct API-contract test — inserting NaN- and Infinite-coordinate regions both throw, and the tree remains usable for subsequent valid inserts.
- [x] Added `RTreeTest.PoisonedInsertAmongNormalDataIsRejectedBeforeAnySplit`: end-to-end reproduction using the exact rectangle sequence (one NaN entry among otherwise normal data, small node capacity to force an R*-tree split) that segfaults on unpatched `main` under AddressSanitizer; now the poisoned insert throws cleanly while every other insert succeeds and `isIndexValid()` holds.
- [x] Reproduced the original segfault against unpatched `main` with `-fsanitize=address,undefined` (ASan confirms `BUS`/SEGV in `RstarSplitEntry::compareHigh` via `qsort` → `Node::rstarSplit` → `Leaf::split` → `Node::insertData`, matching the issue's backtrace), then confirmed the same repro throws cleanly instead of crashing after this fix.
- [x] Full existing gtest suite (21 pre-existing + 2 new = 23) passes under both `BUILD_SHARED_LIBS=ON` and `OFF`, matching CI's matrix, via `ctest -VV --output-on-failure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)